### PR TITLE
Estimator and Simulator

### DIFF
--- a/src/Estimator.sol
+++ b/src/Estimator.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.27;
+
+import { Stage2Module } from "./Stage2Module.sol";
+
+import { Payload } from "./modules/Payload.sol";
+import { IDelegatedExtension } from "./modules/interfaces/IDelegatedExtension.sol";
+import { LibOptim } from "./utils/LibOptim.sol";
+
+contract Estimator is Stage2Module {
+
+  function _isValidImage(
+    bytes32 _imageHash
+  ) internal view virtual override returns (bool) {
+    super._isValidImage(_imageHash);
+    return true;
+  }
+
+  function estimate(
+    bytes calldata _payload,
+    bytes calldata _signature
+  ) external payable virtual returns (uint256 gasUsed) {
+    uint256 startingGas = gasleft();
+    Payload.Decoded memory decoded = Payload.fromPackedCalls(_payload);
+
+    _consumeNonce(decoded.space, readNonce(decoded.space));
+    (bool isValid, bytes32 opHash) = signatureValidation(decoded, _signature);
+
+    if (!isValid) {
+      revert InvalidSignature(decoded, _signature);
+    }
+
+    _estimate(startingGas, opHash, decoded);
+
+    return startingGas - gasleft();
+  }
+
+  function _estimate(uint256 _startingGas, bytes32 _opHash, Payload.Decoded memory _decoded) private {
+    bool errorFlag = false;
+
+    uint256 numCalls = _decoded.calls.length;
+    for (uint256 i = 0; i < numCalls; i++) {
+      Payload.Call memory call = _decoded.calls[i];
+
+      if (errorFlag) {
+        // Always reset the error flag so that
+        // onlyFallback calls only apply when the immediately preceding transaction fails
+        errorFlag = false;
+      } else if (call.onlyFallback) {
+        // If the call is of fallback kind and errorFlag is set to false,
+        // then we can skip the call
+        emit CallSkipped(_opHash, i);
+        continue;
+      }
+
+      uint256 gasLimit = call.gasLimit;
+      if (gasLimit != 0 && gasleft() < gasLimit) {
+        revert NotEnoughGas(_decoded, i, gasleft());
+      }
+
+      bool success;
+      if (call.delegateCall) {
+        (success) = LibOptim.delegatecall(
+          call.to,
+          gasLimit == 0 ? gasleft() : gasLimit,
+          abi.encodeWithSelector(
+            IDelegatedExtension.handleSequenceDelegateCall.selector,
+            _opHash,
+            _startingGas,
+            i,
+            numCalls,
+            _decoded.space,
+            call.data
+          )
+        );
+      } else {
+        (success) = LibOptim.call(call.to, call.value, gasLimit == 0 ? gasleft() : gasLimit, call.data);
+      }
+
+      if (!success) {
+        if (call.behaviorOnError == Payload.BEHAVIOR_IGNORE_ERROR) {
+          errorFlag = true;
+          emit CallFailed(_opHash, i, LibOptim.returnData());
+          continue;
+        }
+
+        if (call.behaviorOnError == Payload.BEHAVIOR_REVERT_ON_ERROR) {
+          revert Reverted(_decoded, i, LibOptim.returnData());
+        }
+
+        if (call.behaviorOnError == Payload.BEHAVIOR_ABORT_ON_ERROR) {
+          emit CallAborted(_opHash, i, LibOptim.returnData());
+          break;
+        }
+      }
+
+      emit CallSucceeded(_opHash, i);
+    }
+  }
+
+}

--- a/src/Simulator.sol
+++ b/src/Simulator.sol
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.27;
+
+import { Payload } from "./modules/Payload.sol";
+import { IDelegatedExtension } from "./modules/interfaces/IDelegatedExtension.sol";
+import { LibOptim } from "./utils/LibOptim.sol";
+
+contract Simulator {
+
+  enum Status {
+    Skipped,
+    Succeeded,
+    Failed,
+    Aborted,
+    Reverted,
+    NotEnoughGas
+  }
+
+  struct Result {
+    Status status;
+    bytes result;
+    uint256 gasUsed;
+  }
+
+  function simulate(
+    Payload.Call[] calldata _calls
+  ) external returns (Result[] memory results) {
+    uint256 startingGas = gasleft();
+    bool errorFlag = false;
+
+    uint256 numCalls = _calls.length;
+    results = new Result[](numCalls);
+    for (uint256 i = 0; i < numCalls; i++) {
+      Payload.Call memory call = _calls[i];
+
+      if (errorFlag) {
+        // Always reset the error flag so that
+        // onlyFallback calls only apply when the immediately preceding transaction fails
+        errorFlag = false;
+      } else if (call.onlyFallback) {
+        // If the call is of fallback kind and errorFlag is set to false,
+        // then we can skip the call
+        continue;
+      }
+
+      uint256 gasLimit = call.gasLimit;
+      if (gasLimit != 0 && gasleft() < gasLimit) {
+        results[i].status = Status.NotEnoughGas;
+        results[i].result = abi.encode(gasleft());
+        return results;
+      }
+
+      bool success;
+      if (call.delegateCall) {
+        uint256 initial = gasleft();
+        (success) = LibOptim.delegatecall(
+          call.to,
+          gasLimit == 0 ? gasleft() : gasLimit,
+          abi.encodeWithSelector(
+            IDelegatedExtension.handleSequenceDelegateCall.selector, 0, startingGas, i, numCalls, 0, call.data
+          )
+        );
+        results[i].gasUsed = initial - gasleft();
+      } else {
+        uint256 initial = gasleft();
+        (success) = LibOptim.call(call.to, call.value, gasLimit == 0 ? gasleft() : gasLimit, call.data);
+        results[i].gasUsed = initial - gasleft();
+      }
+
+      if (!success) {
+        if (call.behaviorOnError == Payload.BEHAVIOR_IGNORE_ERROR) {
+          errorFlag = true;
+          results[i].status = Status.Failed;
+          results[i].result = LibOptim.returnData();
+          continue;
+        }
+
+        if (call.behaviorOnError == Payload.BEHAVIOR_REVERT_ON_ERROR) {
+          results[i].status = Status.Reverted;
+          results[i].result = LibOptim.returnData();
+          return results;
+        }
+
+        if (call.behaviorOnError == Payload.BEHAVIOR_ABORT_ON_ERROR) {
+          results[i].status = Status.Aborted;
+          results[i].result = LibOptim.returnData();
+          break;
+        }
+      }
+
+      results[i].status = Status.Succeeded;
+      results[i].result = LibOptim.returnData();
+    }
+  }
+
+}


### PR DESCRIPTION
We actually need to estimate/simulate two different things:
  1. Estimate the total gas that the relayer will use when dispatching the user's transactions so that:
    a. We can quote a price for sending the user's transactions to the network
  2. Simulate the execution of each of the user's transactions so that:
    a. We can tell the user which ones will fail, if any
    b. We can provide gas limits for each individual transaction, by using each one's estimated gas usage

Both (1) and (2) happen before the user has signed the transaction, so we can never expect a valid signature and therefore need to rely on stub signatures.

For (1):
  We can use the general gas estimator with the module implementations overridden to:
    1. Accept any signature as valid, but the actual validation itself still needs to occur in order to account for its gas usage
    2. Accept any nonce as valid, again still performing the validation in order to account for its gas usage

For (2):
  This is the case where we can skip signature and nonce validation here entirely because we're not estimating the total gas usage. We call the wallet with the module implementations overridden to:
    1. Either don't validate the signature or validate, but always accept any signature
    2. Either don't validate the nonce or validate, but always accept any nonce
    3. Record the status, result, and gas usage of each individual call
    4. Return instead of revert
    5. Optionally remove any event log emissions

The confusion is because we've only written one implementation that tries to cover both cases.

In order to cover both cases, the single implementation must:
  1. Always perform signature validation, accepting any signature
  2. Always perform nonce validation, accepting any nonce
  3. Record the status, result, and gas usage of each individual call
  4. Return instead of revert
  5. Optionally remove any event log emissions

The downsides of using the same implementation for both cases:
  1. Case (2) computes a bit more than necessary, probably negligible in practice though
  2. Case (1) will have a discrepancy in its gas usage estimate due to replacing event logs with returned results, and returning rather than reverting

IMO, it kind of costs us nothing in order to implement the two cases separately though and is going to be better and more accurate.