### PR TITLE
Pass vars to delegate call

### DIFF
--- a/src/modules/Calls.sol
+++ b/src/modules/Calls.sol
@@ -6,6 +6,7 @@ import { Nonce } from "./Nonce.sol";
 import { Payload } from "./Payload.sol";
 import { BaseAuth } from "./auth/BaseAuth.sol";
 import { SelfAuth } from "./auth/SelfAuth.sol";
+import { IDelegatedExtension } from "./interfaces/IDelegatedExtension.sol";
 
 abstract contract Calls is BaseAuth, Nonce {
 
@@ -66,7 +67,15 @@ abstract contract Calls is BaseAuth, Nonce {
         (success) = LibOptim.delegatecall(
           call.to,
           gasLimit == 0 ? gasleft() : gasLimit,
-          abi.encode(_opHash, _startingGas, i, numCalls, _decoded.space, call.data)
+          abi.encodeWithSelector(
+            IDelegatedExtension.handleSequenceDelegateCall.selector,
+            _opHash,
+            _startingGas,
+            i,
+            numCalls,
+            _decoded.space,
+            call.data
+          )
         );
       } else {
         (success) = LibOptim.call(call.to, call.value, gasLimit == 0 ? gasleft() : gasLimit, call.data);

--- a/src/modules/interfaces/IDelegatedExtension.sol
+++ b/src/modules/interfaces/IDelegatedExtension.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.27;
+
+interface IDelegatedExtension {
+
+  function handleSequenceDelegateCall(
+    bytes32 _opHash,
+    uint256 _startingGas,
+    uint256 _index,
+    uint256 _numCalls,
+    uint256 _space,
+    bytes calldata _data
+  ) external;
+
+}

--- a/test/modules/Calls.t.sol
+++ b/test/modules/Calls.t.sol
@@ -7,7 +7,10 @@ import { Payload } from "../../src/modules/Payload.sol";
 import { AdvTest } from "../utils/TestUtils.sol";
 
 import { Payload } from "../../src/modules/Payload.sol";
+
+import { IDelegatedExtension } from "../../src/modules/interfaces/IDelegatedExtension.sol";
 import { PrimitivesRPC } from "../utils/PrimitivesRPC.sol";
+
 import "forge-std/console.sol";
 
 contract CallsImp is Calls {
@@ -52,7 +55,7 @@ contract CallsImp is Calls {
 
 }
 
-contract MockDelegatecall {
+contract MockDelegatecall is IDelegatedExtension {
 
   event OpHash(bytes32 _opHash);
   event StartingGas(uint256 _startingGas);
@@ -61,16 +64,20 @@ contract MockDelegatecall {
   event Space(uint256 _space);
   event Data(bytes _data);
 
-  fallback() external {
-    (bytes32 opHash, uint256 startingGas, uint256 i, uint256 numCalls, uint256 space, bytes memory data) =
-      abi.decode(msg.data, (bytes32, uint256, uint256, uint256, uint256, bytes));
-
-    emit OpHash(opHash);
-    emit StartingGas(startingGas);
-    emit Index(i);
-    emit NumCalls(numCalls);
-    emit Space(space);
-    emit Data(data);
+  function handleSequenceDelegateCall(
+    bytes32 _opHash,
+    uint256 _startingGas,
+    uint256 _index,
+    uint256 _numCalls,
+    uint256 _space,
+    bytes calldata _data
+  ) external {
+    emit OpHash(_opHash);
+    emit StartingGas(_startingGas);
+    emit Index(_index);
+    emit NumCalls(_numCalls);
+    emit Space(_space);
+    emit Data(_data);
   }
 
 }


### PR DESCRIPTION
This is an alternative to https://github.com/0xsequence/sequence-v3/pull/19, and the necessary scaffolding needed to implement proper fee refunds.

The idea is that we pass additional information when `delegateCall: true`, information that may be either be hard (or impossible) to compute from within the "implementation contract".

- `opHash`: Can't be included on `calldata` because `opHash` depends on the calldata, circular dependency
- `startingGas`: Not directly observable, unless an special entrypoint (and transient storage) is used
- `i`: Could be passed, but couldn't be verified.
- `numCalls`: Could be passed, but couldn't be verified
- `space`: Could be passed, but couldn't be verified (there is no record of which nonce incremented last)

Any other ideas of things that we may want to pass on `delegateCall`?