### PR TITLE
Update explicit sessions to allow message signing

### DIFF
--- a/src/extensions/sessions/explicit/IExplicitSessionManager.sol
+++ b/src/extensions/sessions/explicit/IExplicitSessionManager.sol
@@ -7,6 +7,8 @@ import { Permission, UsageLimit } from "./Permission.sol";
 struct SessionPermissions {
   /// @notice Address of the session signer these permissions apply to
   address signer;
+  /// @notice Whether signing messages is allowed
+  bool allowMessages;
   /// @notice Maximum native token value this signer can send
   uint256 valueLimit;
   /// @notice Deadline for the session. (0 = no deadline)

--- a/test/extensions/sessions/SessionTestBase.sol
+++ b/test/extensions/sessions/SessionTestBase.sol
@@ -28,11 +28,16 @@ abstract contract SessionTestBase is AdvTest {
   /// @dev Encodes the explicit config.
   function _encodeExplicitConfig(
     address signer,
+    bool allowMessages,
     uint256 valueLimit,
     uint256 deadline
   ) internal pure returns (bytes memory) {
+    uint8 flag = uint8(SessionSig.FLAG_PERMISSIONS << 4);
+    if (allowMessages) {
+      flag |= 1;
+    }
     bytes memory node = abi.encodePacked(
-      uint8(SessionSig.FLAG_PERMISSIONS),
+      uint8(flag),
       signer,
       valueLimit,
       deadline,
@@ -58,7 +63,9 @@ abstract contract SessionTestBase is AdvTest {
   ) internal pure returns (string memory) {
     string memory json = '{"signer":"';
     json = string.concat(json, vm.toString(sessionPerms.signer));
-    json = string.concat(json, '","valueLimit":"');
+    json = string.concat(json, '","allowMessages":');
+    json = string.concat(json, sessionPerms.allowMessages ? "true" : "false");
+    json = string.concat(json, ',"valueLimit":"');
     json = string.concat(json, vm.toString(sessionPerms.valueLimit));
     json = string.concat(json, '","deadline":"');
     json = string.concat(json, vm.toString(sessionPerms.deadline));
@@ -169,12 +176,14 @@ abstract contract SessionTestBase is AdvTest {
 
   function _createSessionPermissions(
     address target,
+    bool allowMessages,
     uint256 valueLimit,
     uint256 deadline,
     address signer
   ) internal pure returns (SessionPermissions memory) {
     SessionPermissions memory sessionPerms = SessionPermissions({
       signer: signer,
+      allowMessages: allowMessages,
       valueLimit: valueLimit,
       deadline: deadline,
       permissions: new Permission[](1)

--- a/test/extensions/sessions/explicit/ExplicitSessionManager.t.sol
+++ b/test/extensions/sessions/explicit/ExplicitSessionManager.t.sol
@@ -5,6 +5,7 @@ import { Vm } from "forge-std/Test.sol";
 import { SessionTestBase } from "test/extensions/sessions/SessionTestBase.sol";
 
 import { SessionErrors } from "src/extensions/sessions/SessionErrors.sol";
+import { SessionSig } from "src/extensions/sessions/SessionSig.sol";
 import { ExplicitSessionManager } from "src/extensions/sessions/explicit/ExplicitSessionManager.sol";
 import { IExplicitSessionManager } from "src/extensions/sessions/explicit/IExplicitSessionManager.sol";
 import { SessionPermissions, SessionUsageLimits } from "src/extensions/sessions/explicit/IExplicitSessionManager.sol";
@@ -50,6 +51,7 @@ contract ExplicitSessionManagerTest is SessionTestBase {
     // Create SessionPermissions with one Permission.
     SessionPermissions memory perms = SessionPermissions({
       signer: sessionWallet.addr,
+      allowMessages: false,
       valueLimit: 0, // no native token usage for this test
       deadline: block.timestamp + 1 days,
       permissions: new Permission[](1)
@@ -108,6 +110,7 @@ contract ExplicitSessionManagerTest is SessionTestBase {
     // Create SessionPermissions with a signer that does NOT match the session signer.
     SessionPermissions memory perms = SessionPermissions({
       signer: invalidSigner, // different signer
+      allowMessages: false,
       valueLimit: 100,
       deadline: block.timestamp + 1 days,
       permissions: new Permission[](1)
@@ -147,6 +150,7 @@ contract ExplicitSessionManagerTest is SessionTestBase {
     // Create SessionPermissions with a deadline in the past.
     SessionPermissions memory perms = SessionPermissions({
       signer: sessionWallet.addr,
+      allowMessages: false,
       valueLimit: 100,
       deadline: expiredTimestamp, // expired
       permissions: new Permission[](1)
@@ -189,6 +193,7 @@ contract ExplicitSessionManagerTest is SessionTestBase {
     // Create valid SessionPermissions (won't reach permission check).
     SessionPermissions memory perms = SessionPermissions({
       signer: sessionWallet.addr,
+      allowMessages: false,
       valueLimit: 100,
       deadline: block.timestamp + 1 days,
       permissions: new Permission[](1)
@@ -230,6 +235,7 @@ contract ExplicitSessionManagerTest is SessionTestBase {
     // Need valid session permissions for the test to reach self-call validation
     SessionPermissions memory perms = SessionPermissions({
       signer: sessionWallet.addr, // Match the session signer
+      allowMessages: false,
       valueLimit: 100,
       deadline: block.timestamp + 1 days,
       permissions: new Permission[](1)
@@ -263,6 +269,7 @@ contract ExplicitSessionManagerTest is SessionTestBase {
     // Need valid session permissions for the test to reach self-call validation
     SessionPermissions memory perms = SessionPermissions({
       signer: sessionWallet.addr, // Match the session signer
+      allowMessages: false,
       valueLimit: 100,
       deadline: block.timestamp + 1 days,
       permissions: new Permission[](1)
@@ -296,6 +303,7 @@ contract ExplicitSessionManagerTest is SessionTestBase {
     // Create SessionPermissions with an empty permissions array.
     SessionPermissions memory perms = SessionPermissions({
       signer: sessionWallet.addr,
+      allowMessages: false,
       valueLimit: 100,
       deadline: block.timestamp + 1 days,
       permissions: new Permission[](0)
@@ -330,6 +338,7 @@ contract ExplicitSessionManagerTest is SessionTestBase {
     // Set valueLimit lower than the call value.
     SessionPermissions memory perms = SessionPermissions({
       signer: sessionWallet.addr,
+      allowMessages: false,
       valueLimit: 10, // limit too low
       deadline: block.timestamp + 1 days,
       permissions: new Permission[](1)
@@ -371,6 +380,7 @@ contract ExplicitSessionManagerTest is SessionTestBase {
     // Create SessionPermissions expecting selector 0x12345678.
     SessionPermissions memory perms = SessionPermissions({
       signer: sessionWallet.addr,
+      allowMessages: false,
       valueLimit: 0,
       deadline: block.timestamp + 1 days,
       permissions: new Permission[](1)


### PR DESCRIPTION
* Adds a flag `allowMessages` to the permission for explicit sessions
* Sessions with this flag are allowed to sign ANY message payload (no checks on message content)
* Backwards compatible with the current encoding as the boolean is packed into the `PERMISSION_NODE` flag
* Due to packing, does not increase signature payload size