### PR TITLE
Forward value and data

### DIFF
--- a/src/Wallet.huff
+++ b/src/Wallet.huff
@@ -1,10 +1,10 @@
 // Delegate Proxy in Huff
 // @title Delegate Proxy
 // @notice Implements a proxy that uses the contract's own address to store the location of the proxy.
-// All calls are forwarded to the stored proxy address as long as they don't include value.
+// All calls are forwarded to the stored proxy address as long as they don't include value
 // @author Agusx1211
 #define macro CONSTRUCTOR() = takes (0) returns (0) {
-  0x3e                   // [code + arg size] (code_size + 32)
+  0x41                   // [code + arg size] (code_size + 32)
   __codeoffset(MAIN)     // [code_start, code + arg size]
   returndatasize         // [0, code_start, code + arg size]
   codecopy               // []
@@ -22,8 +22,11 @@
 #define macro MAIN() = takes(0) returns(0) {
   returndatasize     // [0]
   returndatasize     // [0, 0]
-  callvalue          // [cv, 0, 0]
-  success            // [nr, cv, 0, 0]
+  calldatasize       // [cs, 0, 0]
+  iszero             // [cs == 0, 0, 0]
+  callvalue          // [cv, cs == 0, 0, 0]
+  mul                // [cv * cs == 0, 0, 0]
+  success            // [nr, cv * cs == 0, 0, 0]
   jumpi
     calldatasize     // [cds, 0, 0]
     returndatasize   // [0, cds, 0, 0]

--- a/src/Wallet.sol
+++ b/src/Wallet.sol
@@ -5,10 +5,10 @@ pragma solidity ^0.8.0;
 // Delegate Proxy in Huff
 // @title Delegate Proxy
 // @notice Implements a proxy that uses the contract's own address to store the location of the proxy.
-// All calls are forwarded to the stored proxy address as long as they don't include value.
+// All calls are forwarded to the stored proxy address as long as they don't include value
 // @author Agusx1211
 #define macro CONSTRUCTOR() = takes (0) returns (0) {
-  0x3e                   // [code + arg size] (code_size + 32)
+  0x41                   // [code + arg size] (code_size + 32)
   __codeoffset(MAIN)     // [code_start, code + arg size]
   returndatasize         // [0, code_start, code + arg size]
   codecopy               // []
@@ -26,8 +26,11 @@ pragma solidity ^0.8.0;
 #define macro MAIN() = takes(0) returns(0) {
   returndatasize     // [0]
   returndatasize     // [0, 0]
-  callvalue          // [cv, 0, 0]
-  success            // [nr, cv, 0, 0]
+  calldatasize       // [cs, 0, 0]
+  iszero             // [cs == 0, 0, 0]
+  callvalue          // [cv, cs == 0, 0, 0]
+  mul                // [cv * cs == 0, 0, 0]
+  success            // [nr, cv * cs == 0, 0, 0]
   jumpi
     calldatasize     // [cds, 0, 0]
     returndatasize   // [0, cds, 0, 0]
@@ -58,6 +61,6 @@ pragma solidity ^0.8.0;
 library Wallet {
 
   bytes internal constant creationCode =
-    hex"603e600e3d39601e805130553df33d3d34601c57363d3d373d363d30545af43d82803e903d91601c57fd5bf3";
+    hex"6041600e3d396021805130553df33d3d36153402601f57363d3d373d363d30545af43d82803e903d91601f57fd5bf3";
 
 }

--- a/test/Wallet.t.sol
+++ b/test/Wallet.t.sol
@@ -20,18 +20,38 @@ contract ModuleImp {
 
   VariableDataStore public immutable expectedDataPointer;
   VariableDataStore public immutable willReturnPointer;
+  uint256 public immutable expectedValue;
+  bool public immutable alwaysReverts;
 
-  constructor(bytes memory _expectedData, bytes memory _willReturn) {
+  constructor(bytes memory _expectedData, bytes memory _willReturn, uint256 _expectedValue, bool _alwaysReverts) {
     expectedDataPointer = new VariableDataStore(_expectedData);
     willReturnPointer = new VariableDataStore(_willReturn);
+    expectedValue = _expectedValue;
+    alwaysReverts = _alwaysReverts;
   }
 
-  fallback() external {
+  receive() external payable {
+    _verifyAndReturn();
+  }
+
+  fallback() external payable {
+    _verifyAndReturn();
+  }
+
+  function _verifyAndReturn() internal {
+    if (alwaysReverts) {
+      revert("Always reverts");
+    }
+
     bytes memory expectedData = expectedDataPointer.data();
     bytes memory willReturn = willReturnPointer.data();
 
     if (keccak256(expectedData) != keccak256(msg.data)) {
       revert("Invalid data");
+    }
+
+    if (msg.value != expectedValue) {
+      revert("Invalid value");
     }
 
     assembly {
@@ -50,13 +70,39 @@ contract WalletTest is AdvTest {
   }
 
   function test_forward(bytes32 _salt, bytes calldata _data, bytes calldata _return) external {
-    address to = address(0x1234);
-    vm.mockCall(to, _data, _return);
-
-    ModuleImp module = new ModuleImp(_data, _return);
+    ModuleImp module = new ModuleImp(_data, _return, 0, false);
     address wallet = factory.deploy(address(module), _salt);
 
     (bool success, bytes memory returnData) = wallet.call(_data);
+    assertEq(success, true);
+    assertEq(returnData, _return);
+  }
+
+  function test_doNotForwardWithValue(bytes32 _salt, uint256 _value) external {
+    vm.assume(_value > 0);
+
+    vm.deal(address(this), _value);
+    ModuleImp module = new ModuleImp(bytes(""), bytes(""), 0, true);
+    address wallet = factory.deploy(address(module), _salt);
+
+    (bool success, bytes memory returnData) = wallet.call{ value: _value }(bytes(""));
+    assertEq(success, true);
+    assertEq(returnData, bytes(""));
+  }
+
+  function test_forwardValueWithData(
+    bytes32 _salt,
+    bytes calldata _data,
+    bytes calldata _return,
+    uint256 _value
+  ) external {
+    vm.assume(_data.length > 0);
+
+    vm.deal(address(this), _value);
+    ModuleImp module = new ModuleImp(_data, _return, _value, false);
+    address wallet = factory.deploy(address(module), _salt);
+
+    (bool success, bytes memory returnData) = wallet.call{ value: _value }(_data);
     assertEq(success, true);
     assertEq(returnData, _return);
   }


### PR DESCRIPTION
Allows the wallet to implement "payable hooks", when the wallet proxy sees a call with value **and** data, it forwards the call to the implementation.

This maintains support for `.transfer`