### PR TITLE
Add chain id to explicit session permissions

### DIFF
--- a/src/extensions/sessions/SessionErrors.sol
+++ b/src/extensions/sessions/SessionErrors.sol
@@ -8,6 +8,8 @@ library SessionErrors {
 
   /// @notice Invalid session signer
   error InvalidSessionSigner(address invalidSigner);
+  /// @notice Invalid chainId
+  error InvalidChainId(uint256 invalidChainId);
   /// @notice Invalid self call
   error InvalidSelfCall();
   /// @notice Invalid delegate call

--- a/src/extensions/sessions/SessionSig.sol
+++ b/src/extensions/sessions/SessionSig.sol
@@ -23,7 +23,7 @@ library SessionSig {
   uint256 internal constant FLAG_BLACKLIST = 3;
   uint256 internal constant FLAG_IDENTITY_SIGNER = 4;
 
-  uint256 internal constant MIN_ENCODED_PERMISSION_SIZE = 62;
+  uint256 internal constant MIN_ENCODED_PERMISSION_SIZE = 94;
 
   /// @notice Call signature for a specific session
   /// @param isImplicit If the call is implicit
@@ -218,6 +218,9 @@ library SessionSig {
 
         // Read signer
         (nodePermissions.signer, pointer) = encoded.readAddress(pointer);
+
+        // Read chainId
+        (nodePermissions.chainId, pointer) = encoded.readUint256(pointer);
 
         // Read value limit
         (nodePermissions.valueLimit, pointer) = encoded.readUint256(pointer);

--- a/src/extensions/sessions/explicit/ExplicitSessionManager.sol
+++ b/src/extensions/sessions/explicit/ExplicitSessionManager.sol
@@ -60,6 +60,11 @@ abstract contract ExplicitSessionManager is IExplicitSessionManager, PermissionV
       revert SessionErrors.InvalidSessionSigner(sessionSigner);
     }
 
+    // Check if session chainId is valid
+    if (sessionPermissions.chainId != 0 && sessionPermissions.chainId != block.chainid) {
+      revert SessionErrors.InvalidChainId(sessionPermissions.chainId);
+    }
+
     // Check if session has expired.
     if (sessionPermissions.deadline != 0 && block.timestamp > sessionPermissions.deadline) {
       revert SessionErrors.SessionExpired(sessionPermissions.deadline);

--- a/src/extensions/sessions/explicit/IExplicitSessionManager.sol
+++ b/src/extensions/sessions/explicit/IExplicitSessionManager.sol
@@ -5,11 +5,13 @@ import { Permission, UsageLimit } from "./Permission.sol";
 
 /// @notice Permissions configuration for a specific session signer
 /// @param signer Address of the session signer these permissions apply to
+/// @param chainId Chain ID of the session (0 = any chain)
 /// @param valueLimit Maximum native token value this signer can send
 /// @param deadline Deadline for the session. (0 = no deadline)
 /// @param permissions Array of encoded permissions granted to this signer
 struct SessionPermissions {
   address signer;
+  uint256 chainId;
   uint256 valueLimit;
   uint64 deadline;
   Permission[] permissions;

--- a/test/extensions/sessions/SessionManager.t.sol
+++ b/test/extensions/sessions/SessionManager.t.sol
@@ -39,7 +39,8 @@ contract SessionManagerTest is SessionTestBase {
     bytes4 selector,
     uint256 param,
     uint256 value,
-    address explicitTarget2
+    address explicitTarget2,
+    bool useChainId
   ) public {
     vm.assume(explicitTarget != explicitTarget2);
     vm.assume(value > 0);
@@ -50,6 +51,7 @@ contract SessionManagerTest is SessionTestBase {
     // Create a SessionPermissions struct granting permission for calls to explicitTarget.
     SessionPermissions memory sessionPerms = SessionPermissions({
       signer: sessionWallet.addr,
+      chainId: useChainId ? block.chainid : 0,
       valueLimit: value,
       deadline: uint64(block.timestamp + 1 days),
       permissions: new Permission[](2)

--- a/test/extensions/sessions/SessionSig.t.sol
+++ b/test/extensions/sessions/SessionSig.t.sol
@@ -44,7 +44,9 @@ contract SessionSigTest is SessionTestBase {
     identityWallet = vm.createWallet("identity");
   }
 
-  function testSingleExplicitSignature() public {
+  function testSingleExplicitSignature(
+    bool useChainId
+  ) public {
     Payload.Decoded memory payload = _buildPayload(1);
     {
       payload.calls[0] = Payload.Call({
@@ -59,6 +61,7 @@ contract SessionSigTest is SessionTestBase {
     }
     SessionPermissions memory sessionPerms = SessionPermissions({
       signer: sessionWallet.addr,
+      chainId: useChainId ? block.chainid : 0,
       valueLimit: 1000,
       deadline: 2000,
       permissions: new Permission[](1)
@@ -244,7 +247,9 @@ contract SessionSigTest is SessionTestBase {
     }
   }
 
-  function testMultipleExplicitSignatures() public {
+  function testMultipleExplicitSignatures(
+    bool useChainId
+  ) public {
     // Create a second session wallet
     Vm.Wallet memory sessionWallet2 = vm.createWallet("session2");
 
@@ -274,8 +279,10 @@ contract SessionSigTest is SessionTestBase {
     // Create session permissions for both calls with different signers
     SessionPermissions[] memory sessionPermsArray = new SessionPermissions[](2);
     {
-      sessionPermsArray[0] = _createSessionPermissions(address(0xBEEF), 1000, 2000, sessionWallet.addr);
-      sessionPermsArray[1] = _createSessionPermissions(address(0xCAFE), 1000, 2000, sessionWallet2.addr);
+      sessionPermsArray[0] =
+        _createSessionPermissions(address(0xBEEF), useChainId ? block.chainid : 0, 1000, 2000, sessionWallet.addr);
+      sessionPermsArray[1] =
+        _createSessionPermissions(address(0xCAFE), useChainId ? block.chainid : 0, 1000, 2000, sessionWallet2.addr);
     }
 
     // Create the topology from the CLI
@@ -346,7 +353,9 @@ contract SessionSigTest is SessionTestBase {
     }
   }
 
-  function testRecover_invalidSessionSigner() public {
+  function testRecover_invalidSessionSigner(
+    bool useChainId
+  ) public {
     Payload.Decoded memory payload = _buildPayload(1);
     {
       payload.calls[0] = Payload.Call({
@@ -361,6 +370,7 @@ contract SessionSigTest is SessionTestBase {
     }
     SessionPermissions memory sessionPerms = SessionPermissions({
       signer: sessionWallet.addr,
+      chainId: useChainId ? block.chainid : 0,
       valueLimit: 1000,
       deadline: 2000,
       permissions: new Permission[](1)
@@ -911,10 +921,16 @@ contract SessionSigTest is SessionTestBase {
     );
   }
 
-  function testEmptyPermissionsStructSize_direct(address signer, uint256 valueLimit, uint64 deadline) public view {
+  function testEmptyPermissionsStructSize_direct(
+    address signer,
+    uint256 chainId,
+    uint256 valueLimit,
+    uint64 deadline
+  ) public view {
     // Create an empty permissions struct
     SessionPermissions memory sessionPerms = SessionPermissions({
       signer: signer,
+      chainId: chainId,
       valueLimit: valueLimit,
       deadline: deadline,
       permissions: new Permission[](0)
@@ -924,6 +940,7 @@ contract SessionSigTest is SessionTestBase {
     bytes memory encoded = abi.encodePacked(
       uint8(SessionSig.FLAG_PERMISSIONS),
       sessionPerms.signer,
+      sessionPerms.chainId,
       sessionPerms.valueLimit,
       sessionPerms.deadline,
       uint8(0) // empty permissions array length
@@ -936,6 +953,7 @@ contract SessionSigTest is SessionTestBase {
     (SessionSig.DecodedSignature memory sig,) = harness.recoverConfiguration(encoded);
     assertEq(sig.sessionPermissions.length, 1, "Should have one permissions struct");
     assertEq(sig.sessionPermissions[0].signer, signer, "Signer should match");
+    assertEq(sig.sessionPermissions[0].chainId, chainId, "Chain ID should match");
     assertEq(sig.sessionPermissions[0].valueLimit, valueLimit, "Value limit should match");
     assertEq(sig.sessionPermissions[0].deadline, deadline, "Deadline should match");
     assertEq(sig.sessionPermissions[0].permissions.length, 0, "Should have no permissions");

--- a/test/extensions/sessions/SessionTestBase.sol
+++ b/test/extensions/sessions/SessionTestBase.sol
@@ -25,22 +25,6 @@ abstract contract SessionTestBase is AdvTest {
     return string(abi.encodePacked(vm.toString(r), ":", vm.toString(s), ":", vm.toString(v)));
   }
 
-  /// @dev Encodes the explicit config.
-  function _encodeExplicitConfig(
-    address signer,
-    uint256 valueLimit,
-    uint64 deadline
-  ) internal pure returns (bytes memory) {
-    bytes memory node = abi.encodePacked(
-      uint8(SessionSig.FLAG_PERMISSIONS),
-      signer,
-      valueLimit,
-      deadline,
-      uint24(0) // empty permissions array length
-    );
-    return abi.encodePacked(uint24(node.length), node);
-  }
-
   /// @dev Helper to build a Payload.Decoded with a given number of calls.
   function _buildPayload(
     uint256 callCount
@@ -58,6 +42,8 @@ abstract contract SessionTestBase is AdvTest {
   ) internal pure returns (string memory) {
     string memory json = '{"signer":"';
     json = string.concat(json, vm.toString(sessionPerms.signer));
+    json = string.concat(json, '","chainId":"');
+    json = string.concat(json, vm.toString(sessionPerms.chainId));
     json = string.concat(json, '","valueLimit":"');
     json = string.concat(json, vm.toString(sessionPerms.valueLimit));
     json = string.concat(json, '","deadline":"');
@@ -171,12 +157,14 @@ abstract contract SessionTestBase is AdvTest {
 
   function _createSessionPermissions(
     address target,
+    uint256 chainId,
     uint256 valueLimit,
     uint64 deadline,
     address signer
   ) internal pure returns (SessionPermissions memory) {
     SessionPermissions memory sessionPerms = SessionPermissions({
       signer: signer,
+      chainId: chainId,
       valueLimit: valueLimit,
       deadline: deadline,
       permissions: new Permission[](1)


### PR DESCRIPTION
0 chain id is global. 

This prevents attacks where a permission granted on one chain gives you access to another. For example, a permission that allows sending likely ETH shouldn't be valid for all chains. 

Requires: https://github.com/0xsequence/sequence.js/pull/806