### PR TITLE
(Fix SEQ-1 and Sessions Reentrancy) Move increment limit to start of batch

### DIFF
--- a/docs/SESSIONS.md
+++ b/docs/SESSIONS.md
@@ -391,11 +391,11 @@ When the **cumulative** flag is set on a permission rule:
 2. **Threshold Comparison:**  
    The cumulative total (current value plus previous usage) is compared against the threshold defined by the rule.
 
-3. **Follow-up Update:**  
-   Because cumulative values persist across multiple calls, a follow-up call to `incrementUsageLimit` is required. This call updates the on-chain storage with the new cumulative total, ensuring that future validations reflect the updated usage.
+3. **Preceding Update:**  
+   Because cumulative values persist across multiple calls, a preceding call to `incrementUsageLimit` is required. This call updates the on-chain storage with the new cumulative total, ensuring that future validations reflect the updated usage.
 
 > [!WARNING]
-> Cumulative Usage Requires Follow-up: Always ensure that an `incrementUsageLimit` call is made after processing a cumulative permission rule to update the stored cumulative usage. Failure to do so may result in incorrect validations on subsequent calls.
+> Cumulative Usage Requires Preceding Call: Always ensure that an `incrementUsageLimit` call is made at the start of the batch when processing a cumulative permission rule to update the stored cumulative usage. Failure to do so may result in incorrect validations on subsequent calls.
 
 ### Example: ERC20.transfer
 

--- a/src/extensions/sessions/SessionErrors.sol
+++ b/src/extensions/sessions/SessionErrors.sol
@@ -14,6 +14,8 @@ library SessionErrors {
   error InvalidSelfCall();
   /// @notice Invalid delegate call
   error InvalidDelegateCall();
+  /// @notice Invalid call behavior
+  error InvalidBehavior();
   /// @notice Invalid value
   error InvalidValue();
   /// @notice Invalid node type in session configuration

--- a/src/extensions/sessions/SessionManager.sol
+++ b/src/extensions/sessions/SessionManager.sol
@@ -50,10 +50,16 @@ contract SessionManager is ISapient, ImplicitSessionManager, ExplicitSessionMana
     SessionUsageLimits[] memory sessionUsageLimits = new SessionUsageLimits[](payload.calls.length);
 
     for (uint256 i = 0; i < payload.calls.length; i++) {
-      // General validation
       Payload.Call calldata call = payload.calls[i];
+
+      // Ban delegate calls
       if (call.delegateCall) {
         revert SessionErrors.InvalidDelegateCall();
+      }
+
+      // Check if this call could cause usage limits to be skipped
+      if (call.behaviorOnError == Payload.BEHAVIOR_ABORT_ON_ERROR) {
+        revert SessionErrors.InvalidBehavior();
       }
 
       // Validate call signature

--- a/src/extensions/sessions/SessionManager.sol
+++ b/src/extensions/sessions/SessionManager.sol
@@ -116,8 +116,8 @@ contract SessionManager is ISapient, ImplicitSessionManager, ExplicitSessionMana
       }
 
       // Bulk validate the updated usage limits
-      Payload.Call calldata lastCall = payload.calls[payload.calls.length - 1];
-      _validateLimitUsageIncrement(lastCall, actualSessionUsageLimits);
+      Payload.Call calldata firstCall = payload.calls[0];
+      _validateLimitUsageIncrement(firstCall, actualSessionUsageLimits);
     }
 
     // Return the image hash

--- a/src/extensions/sessions/explicit/ExplicitSessionManager.sol
+++ b/src/extensions/sessions/explicit/ExplicitSessionManager.sol
@@ -116,7 +116,7 @@ abstract contract ExplicitSessionManager is IExplicitSessionManager, PermissionV
   }
 
   /// @notice Verifies the limit usage increment
-  /// @param call The call to validate
+  /// @param call The first call in the payload, which is expected to be the increment call
   /// @param sessionUsageLimits The session usage limits
   /// @dev Reverts if the required increment call is missing or invalid
   /// @dev If no usage limits are used, this function does nothing
@@ -126,7 +126,7 @@ abstract contract ExplicitSessionManager is IExplicitSessionManager, PermissionV
   ) internal view {
     // Limits call is only required if there are usage limits used
     if (sessionUsageLimits.length > 0) {
-      // Verify the last call is the increment call and cannot be skipped
+      // Verify the first call is the increment call and cannot be skipped
       if (call.to != address(this) || call.behaviorOnError != Payload.BEHAVIOR_REVERT_ON_ERROR || call.onlyFallback) {
         revert SessionErrors.InvalidLimitUsageIncrement();
       }

--- a/src/extensions/sessions/explicit/ExplicitSessionManager.sol
+++ b/src/extensions/sessions/explicit/ExplicitSessionManager.sol
@@ -78,8 +78,11 @@ abstract contract ExplicitSessionManager is IExplicitSessionManager, PermissionV
 
     // Calls to incrementUsageLimit are the only allowed calls to this contract
     if (call.to == address(this)) {
+      if (call.value > 0) {
+        revert SessionErrors.InvalidValue();
+      }
       bytes4 selector = bytes4(call.data[0:4]);
-      if (call.value > 0 || selector != IExplicitSessionManager.incrementUsageLimit.selector) {
+      if (selector != IExplicitSessionManager.incrementUsageLimit.selector) {
         revert SessionErrors.InvalidSelfCall();
       }
       // No permissions required
@@ -123,8 +126,8 @@ abstract contract ExplicitSessionManager is IExplicitSessionManager, PermissionV
   ) internal view {
     // Limits call is only required if there are usage limits used
     if (sessionUsageLimits.length > 0) {
-      // Verify the last call is the increment call
-      if (call.to != address(this) || call.behaviorOnError != Payload.BEHAVIOR_REVERT_ON_ERROR) {
+      // Verify the last call is the increment call and cannot be skipped
+      if (call.to != address(this) || call.behaviorOnError != Payload.BEHAVIOR_REVERT_ON_ERROR || call.onlyFallback) {
         revert SessionErrors.InvalidLimitUsageIncrement();
       }
 

--- a/test/extensions/sessions/SessionCalls.t.sol
+++ b/test/extensions/sessions/SessionCalls.t.sol
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.27;
+
+import { Vm, console } from "forge-std/Test.sol";
+import { SessionTestBase } from "test/extensions/sessions/SessionTestBase.sol";
+
+import { Emitter } from "test/mocks/Emitter.sol";
+import { PrimitivesRPC } from "test/utils/PrimitivesRPC.sol";
+
+import { Factory } from "src/Factory.sol";
+import { Stage1Module } from "src/Stage1Module.sol";
+import { SessionErrors } from "src/extensions/sessions/SessionErrors.sol";
+import { SessionManager } from "src/extensions/sessions/SessionManager.sol";
+import { SessionSig } from "src/extensions/sessions/SessionSig.sol";
+import { SessionPermissions } from "src/extensions/sessions/explicit/IExplicitSessionManager.sol";
+import {
+  ParameterOperation, ParameterRule, Permission, UsageLimit
+} from "src/extensions/sessions/explicit/Permission.sol";
+import { Attestation, LibAttestation } from "src/extensions/sessions/implicit/Attestation.sol";
+import { Calls } from "src/modules/Calls.sol";
+import { ERC4337v07 } from "src/modules/ERC4337v07.sol";
+import { Payload } from "src/modules/Payload.sol";
+import { ISapient } from "src/modules/interfaces/ISapient.sol";
+
+/// @notice Explicit session integration tests.
+contract SessionCallsTest is SessionTestBase {
+
+  Factory public factory;
+  Stage1Module public module;
+  SessionManager public sessionManager;
+  Vm.Wallet public sessionWallet;
+  Vm.Wallet public identityWallet;
+  MockContract public target;
+
+  function setUp() public {
+    sessionWallet = vm.createWallet("session");
+    identityWallet = vm.createWallet("identity");
+    sessionManager = new SessionManager();
+    factory = new Factory();
+    module = new Stage1Module(address(factory), address(0));
+    target = new MockContract();
+  }
+
+  function _validCall(Payload.Call memory call, bool callRevert) internal view returns (Payload.Call memory) {
+    call.to = address(target);
+    call.behaviorOnError = bound(call.behaviorOnError, 0, 2);
+    call.value = bound(call.value, 0, 1 ether);
+    call.data = abi.encodeWithSelector(MockContract.willRevert.selector, callRevert);
+    call.gasLimit = bound(call.gasLimit, 0, 1); // Pass or fail due to gas limit
+
+    // FIXME Remove. This is here to make it pass
+    // call.behaviorOnError = Payload.BEHAVIOR_REVERT_ON_ERROR;
+    // call.onlyFallback = false;
+    // call.data = abi.encodeWithSelector(MockContract.willRevert.selector, false);
+
+    return call;
+  }
+
+  /// forge-config: default.fuzz.runs = 10_000
+  function test_fuzzForSkippingIncrementCall(
+    Payload.Call memory call0,
+    Payload.Call memory call1,
+    Payload.Call memory callIncrement,
+    bool call0Revert,
+    bool call1Revert
+  ) public {
+    Payload.Decoded memory payload = _buildPayload(3);
+    // Fuzzes: Behavior, value, onlyFallback, gasLimit, contract call reverts
+    payload.calls[0] = _validCall(call0, call0Revert);
+    payload.calls[1] = _validCall(call1, call1Revert);
+
+    // FIXME Remove. This is here to make it fail with abort on the second call
+    // payload.calls[0].behaviorOnError = Payload.BEHAVIOR_REVERT_ON_ERROR;
+    // payload.calls[0].onlyFallback = false;
+    // payload.calls[0].value = 1 ether;
+    // payload.calls[1].onlyFallback = false;
+    // payload.calls[1].behaviorOnError = Payload.BEHAVIOR_ABORT_ON_ERROR;
+    // payload.calls[1].data = abi.encodeWithSelector(MockContract.willRevert.selector, true);
+
+    uint256 totalValue = payload.calls[0].value + payload.calls[1].value;
+    vm.assume(totalValue > 0); // Required to use an increment permission
+
+    // Create the increment call
+    UsageLimit[] memory usageLimits = new UsageLimit[](1);
+    usageLimits[0] = UsageLimit({
+      usageHash: keccak256(abi.encode(sessionWallet.addr, sessionManager.VALUE_TRACKING_ADDRESS())),
+      usageAmount: totalValue
+    });
+    callIncrement = _validCall(callIncrement, false);
+    callIncrement.to = address(sessionManager);
+    callIncrement.data = abi.encodeWithSelector(sessionManager.incrementUsageLimit.selector, usageLimits);
+    callIncrement.value = bound(callIncrement.value, 0, 1); // Reduce chance of increment having value. Known failure condition
+    payload.calls[2] = callIncrement;
+
+    // FIXME Remove. Fails as incrementCall aborts on low gas
+    // payload.calls[2].behaviorOnError = Payload.BEHAVIOR_ABORT_ON_ERROR;
+    // payload.calls[2].gasLimit = 1;
+
+    // Create the valid explicit session
+    string memory topology = PrimitivesRPC.sessionEmpty(vm, identityWallet.addr);
+    SessionPermissions memory sessionPerms = SessionPermissions({
+      signer: sessionWallet.addr,
+      chainId: 0,
+      valueLimit: totalValue,
+      deadline: uint64(block.timestamp + 1 days),
+      permissions: new Permission[](1)
+    });
+    sessionPerms.permissions[0] = Permission({ target: address(target), rules: new ParameterRule[](0) });
+    string memory sessionPermsJson = _sessionPermissionsToJSON(sessionPerms);
+    topology = PrimitivesRPC.sessionExplicitAdd(vm, sessionPermsJson, topology);
+    bytes32 sessionImageHash = PrimitivesRPC.sessionImageHash(vm, topology);
+
+    // Create the wallet config
+    string memory config;
+    {
+      string memory ce = string(
+        abi.encodePacked("sapient:", vm.toString(sessionImageHash), ":", vm.toString(address(sessionManager)), ":1")
+      );
+      config = PrimitivesRPC.newConfig(vm, 1, 0, ce);
+    }
+    bytes32 imageHash = PrimitivesRPC.getImageHash(vm, config);
+    Stage1Module wallet = Stage1Module(payable(factory.deploy(address(module), imageHash)));
+
+    // Fund the wallet
+    vm.deal(address(wallet), totalValue + 1);
+
+    // Sign the payload
+    string[] memory callSignatures = new string[](3);
+    for (uint256 i; i < 3; i++) {
+      string memory sessionSignature =
+        _signAndEncodeRSV(SessionSig.hashCallWithReplayProtection(payload.calls[i], payload), sessionWallet);
+      callSignatures[i] = _explicitCallSignatureToJSON(0, sessionSignature);
+    }
+    address[] memory explicitSigners = new address[](1);
+    explicitSigners[0] = sessionWallet.addr;
+    address[] memory implicitSigners = new address[](0);
+    bytes memory sessionSignatures =
+      PrimitivesRPC.sessionEncodeCallSignatures(vm, topology, callSignatures, explicitSigners, implicitSigners);
+    string memory signatures =
+      string(abi.encodePacked(vm.toString(address(sessionManager)), ":sapient:", vm.toString(sessionSignatures)));
+    bytes memory encodedSignature = PrimitivesRPC.toEncodedSignature(vm, config, signatures, false);
+
+    // Execute the payload
+    bytes memory packedPayload = PrimitivesRPC.toPackedPayload(vm, payload);
+    try wallet.execute(packedPayload, encodedSignature) {
+      // If execution succeeds, check the increment is updated
+      uint256 usageAmount = sessionManager.getLimitUsage(address(wallet), usageLimits[0].usageHash);
+      assertEq(usageAmount, totalValue, "Usage should increment on successful execution");
+      // It doesn't matter if the wallet spends funds or not
+      // (error and IGNORE, error and IGNORE, increment) is ok
+    } catch (bytes memory reason) {
+      // If the execution reverts, check the wallet balance is unaffected
+      bytes4 errorSelector = bytes4(reason);
+      if (
+        errorSelector == SessionErrors.InvalidBehavior.selector
+          || errorSelector == SessionErrors.InvalidDelegateCall.selector
+          || errorSelector == SessionErrors.InvalidValue.selector || errorSelector == Calls.NotEnoughGas.selector
+          || errorSelector == Calls.Reverted.selector || errorSelector == MockContract.MockError.selector
+      ) {
+        // Should not spend funds or update usage limits
+        assertEq(address(wallet).balance, totalValue + 1, "Wallet balance should not change");
+        uint256 usageAmount = sessionManager.getLimitUsage(address(wallet), usageLimits[0].usageHash);
+        assertEq(usageAmount, 0, "Usage should not increment");
+      } else if (errorSelector == SessionErrors.InvalidLimitUsageIncrement.selector) {
+        if (callIncrement.behaviorOnError != Payload.BEHAVIOR_REVERT_ON_ERROR || callIncrement.onlyFallback) {
+          // Expected. Should not spend funds or update usage limits
+          assertEq(address(wallet).balance, totalValue + 1, "Wallet balance should not change");
+          uint256 usageAmount = sessionManager.getLimitUsage(address(wallet), usageLimits[0].usageHash);
+          assertEq(usageAmount, 0, "Usage should not increment");
+        } else {
+          revert("Test not correctly fuzzed. This should always pass.");
+        }
+      } else {
+        revert("Got an unexpected error. Update tests to handle this error.");
+      }
+    }
+  }
+
+}
+
+contract MockContract {
+
+  error MockError();
+
+  function willRevert(
+    bool doRevert
+  ) public payable {
+    if (doRevert) {
+      revert MockError();
+    }
+  }
+
+}

--- a/test/extensions/sessions/SessionManager.t.sol
+++ b/test/extensions/sessions/SessionManager.t.sol
@@ -49,6 +49,8 @@ contract SessionManagerTest is SessionTestBase {
     vm.assume(explicitTarget != explicitTarget2);
     vm.assume(value > 0);
     vm.assume(param > 0);
+    vm.assume(explicitTarget != address(sessionManager));
+    vm.assume(explicitTarget2 != address(sessionManager));
     bytes memory callData = abi.encodeWithSelector(selector, param);
 
     // --- Session Permissions ---

--- a/test/extensions/sessions/SessionManager.t.sol
+++ b/test/extensions/sessions/SessionManager.t.sol
@@ -145,6 +145,7 @@ contract SessionManagerTest is SessionTestBase {
     CanReenter canReenter = new CanReenter();
     Factory factory = new Factory();
     Stage1Module stage1Module = new Stage1Module(address(factory), address(0));
+    Vm.Wallet memory badGuy = vm.createWallet("badGuy");
 
     // --- Session Permissions ---
     // Create a SessionPermissions struct granting permission for calls to explicitTarget.
@@ -157,7 +158,6 @@ contract SessionManagerTest is SessionTestBase {
     });
     // Permission with an empty rules set allows all calls to the target.
     ParameterRule[] memory rules = new ParameterRule[](2);
-    // Rules for explicitTarget in call 0.
     rules[0] = ParameterRule({
       cumulative: false,
       operation: ParameterOperation.EQUAL,
@@ -208,7 +208,7 @@ contract SessionManagerTest is SessionTestBase {
     reentrantPayload.calls[0] = Payload.Call({
       to: address(token),
       value: 0,
-      data: abi.encodeWithSelector(token.transfer.selector, explicitTarget, 0.5 ether),
+      data: abi.encodeWithSelector(token.transfer.selector, badGuy.addr, 0.5 ether),
       gasLimit: 0,
       delegateCall: false,
       onlyFallback: false,
@@ -277,7 +277,7 @@ contract SessionManagerTest is SessionTestBase {
     payload.calls[0] = Payload.Call({
       to: address(token),
       value: 0,
-      data: abi.encodeWithSelector(token.transfer.selector, explicitTarget, 1 ether),
+      data: abi.encodeWithSelector(token.transfer.selector, badGuy.addr, 1 ether),
       gasLimit: 0,
       delegateCall: false,
       onlyFallback: false,
@@ -350,7 +350,7 @@ contract SessionManagerTest is SessionTestBase {
     Stage1Module(wallet).execute(packedPayload, mainSignature);
 
     // Bad guy should have 0 funds
-    assertEq(token.balanceOf(explicitTarget), 0);
+    assertEq(token.balanceOf(badGuy.addr), 0);
   }
 
   function testInvalidPayloadKindReverts() public {

--- a/test/extensions/sessions/SessionManager.t.sol
+++ b/test/extensions/sessions/SessionManager.t.sol
@@ -26,7 +26,6 @@ import { MockERC20 } from "test/mocks/MockERC20.sol";
 contract SessionManagerTest is SessionTestBase {
 
   SessionManager public sessionManager;
-  address public explicitTarget;
   Vm.Wallet public sessionWallet;
   Vm.Wallet public identityWallet;
   Emitter public emitter;
@@ -35,7 +34,6 @@ contract SessionManagerTest is SessionTestBase {
     sessionManager = new SessionManager();
     sessionWallet = vm.createWallet("session");
     identityWallet = vm.createWallet("identity");
-    explicitTarget = address(0xBEEF);
     emitter = new Emitter();
   }
 
@@ -44,6 +42,7 @@ contract SessionManagerTest is SessionTestBase {
     bytes4 selector,
     uint256 param,
     uint256 value,
+    address explicitTarget,
     address explicitTarget2,
     bool useChainId
   ) public {
@@ -80,11 +79,6 @@ contract SessionManagerTest is SessionTestBase {
     });
     sessionPerms.permissions[0] = Permission({ target: explicitTarget, rules: rules });
     sessionPerms.permissions[1] = Permission({ target: explicitTarget2, rules: new ParameterRule[](0) }); // Unlimited access
-
-    // Build the session topology using PrimitiveRPC.
-    string memory topology = PrimitivesRPC.sessionEmpty(vm, identityWallet.addr);
-    string memory sessionPermsJson = _sessionPermissionsToJSON(sessionPerms);
-    topology = PrimitivesRPC.sessionExplicitAdd(vm, sessionPermsJson, topology);
 
     // Build a payload with two calls:
     //   Call 0: call not requiring incrementUsageLimit
@@ -134,35 +128,16 @@ contract SessionManagerTest is SessionTestBase {
       });
     }
 
-    // --- Call Signatures ---
-    string[] memory callSignatures = new string[](3);
-    {
-      // Sign the explicit call (call 0) using the session key.
-      string memory sessionSignature =
-        _signAndEncodeRSV(SessionSig.hashCallWithReplayProtection(payload.calls[0], payload), sessionWallet);
-      callSignatures[0] = _explicitCallSignatureToJSON(0, sessionSignature);
-      // Sign the explicit call (call 1) using the session key.
-      sessionSignature =
-        _signAndEncodeRSV(SessionSig.hashCallWithReplayProtection(payload.calls[1], payload), sessionWallet);
-      callSignatures[1] = _explicitCallSignatureToJSON(1, sessionSignature);
-      // Sign the self call (call 2) using the session key.
-      sessionSignature =
-        _signAndEncodeRSV(SessionSig.hashCallWithReplayProtection(payload.calls[2], payload), sessionWallet);
-      callSignatures[2] = _explicitCallSignatureToJSON(0, sessionSignature);
-    }
+    uint8[] memory permissionIdxs = new uint8[](3);
+    permissionIdxs[0] = 0; // Call 0
+    permissionIdxs[1] = 1; // Call 1
+    permissionIdxs[2] = 0; // Call 2
 
-    // Encode the full signature.
-    address[] memory explicitSigners = new address[](1);
-    explicitSigners[0] = sessionWallet.addr;
-    address[] memory implicitSigners = new address[](0);
-    bytes memory encodedSig =
-      PrimitivesRPC.sessionEncodeCallSignatures(vm, topology, callSignatures, explicitSigners, implicitSigners);
+    (bytes32 imageHash, bytes memory encodedSig) = _validExplicitSessionSignature(payload, sessionPerms, permissionIdxs);
 
-    // --- Validate the Payload Signature ---
     vm.prank(sessionWallet.addr);
-    bytes32 imageHash = sessionManager.recoverSapientSignature(payload, encodedSig);
-    bytes32 expectedImageHash = PrimitivesRPC.sessionImageHash(vm, topology);
-    assertEq(imageHash, expectedImageHash);
+    bytes32 actualImageHash = sessionManager.recoverSapientSignature(payload, encodedSig);
+    assertEq(imageHash, actualImageHash);
   }
 
   function testIncrementReentrancy() external {
@@ -395,17 +370,19 @@ contract SessionManagerTest is SessionTestBase {
     sessionManager.recoverSapientSignature(payload, encodedSig);
   }
 
-  function testInvalidCallsLengthReverts() public {
+  function testInvalidCallsLengthReverts(
+    bytes memory sig
+  ) public {
     Payload.Decoded memory payload;
     payload.kind = Payload.KIND_TRANSACTIONS;
-    bytes memory encodedSig;
 
     vm.expectRevert(SessionManager.InvalidCallsLength.selector);
-    sessionManager.recoverSapientSignature(payload, encodedSig);
+    sessionManager.recoverSapientSignature(payload, sig);
   }
 
   /// @notice Test that a call using delegateCall reverts.
-  function testInvalidDelegateCallReverts(Attestation memory attestation, bytes memory data) public {
+  function testInvalidDelegateCallReverts(Attestation memory attestation, bytes memory data, address target) public {
+    vm.assume(target != address(sessionManager));
     attestation.approvedSigner = sessionWallet.addr;
     attestation.authData.redirectUrl = "https://example.com"; // Normalise for safe JSONify
     attestation.authData.issuedAt = uint64(bound(attestation.authData.issuedAt, 0, block.timestamp));
@@ -414,7 +391,7 @@ contract SessionManagerTest is SessionTestBase {
     uint256 callCount = 1;
     Payload.Decoded memory payload = _buildPayload(callCount);
     payload.calls[0] = Payload.Call({
-      to: explicitTarget,
+      to: target,
       value: 0,
       data: data,
       gasLimit: 0,
@@ -423,91 +400,9 @@ contract SessionManagerTest is SessionTestBase {
       behaviorOnError: Payload.BEHAVIOR_REVERT_ON_ERROR
     });
 
-    // Build topology (even though it won’t be used because the delegateCall check runs first).
-    string memory topology = PrimitivesRPC.sessionEmpty(vm, identityWallet.addr);
-    string[] memory callSignatures = new string[](1);
-    callSignatures[0] = _createImplicitCallSignature(payload, 0, sessionWallet, identityWallet, attestation);
-    address[] memory explicitSigners = new address[](0);
-    address[] memory implicitSigners = new address[](1);
-    implicitSigners[0] = sessionWallet.addr;
-    bytes memory encodedSig =
-      PrimitivesRPC.sessionEncodeCallSignatures(vm, topology, callSignatures, explicitSigners, implicitSigners);
+    (, bytes memory encodedSig) = _validImplicitSessionSignature(payload);
 
     vm.expectRevert(SessionErrors.InvalidDelegateCall.selector);
-    sessionManager.recoverSapientSignature(payload, encodedSig);
-  }
-
-  /// @notice Test that a self–call with nonzero value reverts with InvalidSelfCall.
-  function testInvalidSelfCallReverts() public {
-    // Build a payload with two calls:
-    //   Call 0: valid explicit call.
-    //   Call 1: self–call (incrementUsageLimit) with nonzero value (invalid).
-    uint256 callCount = 2;
-    Payload.Decoded memory payload = _buildPayload(callCount);
-
-    // --- Explicit Call (Call 0) ---
-    bytes memory explicitCallData = abi.encodeWithSelector(0x12345678, uint256(42));
-    payload.calls[0] = Payload.Call({
-      to: explicitTarget,
-      value: 0,
-      data: explicitCallData,
-      gasLimit: 0,
-      delegateCall: false,
-      onlyFallback: false,
-      behaviorOnError: Payload.BEHAVIOR_REVERT_ON_ERROR
-    });
-
-    // --- Self Call (Call 1) ---
-    // Intentionally set nonzero value.
-    payload.calls[1] = Payload.Call({
-      to: address(sessionManager),
-      value: 1, // nonzero -> should revert
-      data: abi.encodeWithSelector(sessionManager.incrementUsageLimit.selector, new UsageLimit[](0)),
-      gasLimit: 0,
-      delegateCall: false,
-      onlyFallback: false,
-      behaviorOnError: Payload.BEHAVIOR_REVERT_ON_ERROR
-    });
-
-    // Session permissions for call 0.
-    SessionPermissions memory sessionPerms;
-    sessionPerms.signer = sessionWallet.addr;
-    sessionPerms.valueLimit = 0;
-    sessionPerms.deadline = uint64(block.timestamp + 1 days);
-    sessionPerms.permissions = new Permission[](1);
-    sessionPerms.permissions[0] = Permission({ target: explicitTarget, rules: new ParameterRule[](1) });
-    sessionPerms.permissions[0].rules[0] = ParameterRule({
-      cumulative: false,
-      operation: ParameterOperation.EQUAL,
-      value: bytes32(uint256(uint32(0x12345678)) << 224),
-      offset: 0,
-      mask: bytes32(uint256(uint32(0xffffffff)) << 224)
-    });
-
-    string memory topology = PrimitivesRPC.sessionEmpty(vm, identityWallet.addr);
-    string memory sessionPermsJson = _sessionPermissionsToJSON(sessionPerms);
-    topology = PrimitivesRPC.sessionExplicitAdd(vm, sessionPermsJson, topology);
-
-    // --- Call Signatures ---
-    // For call 0:
-    string memory sessionSignature0 =
-      _signAndEncodeRSV(SessionSig.hashCallWithReplayProtection(payload.calls[0], payload), sessionWallet);
-    string memory callSig0 = _explicitCallSignatureToJSON(0, sessionSignature0);
-    // For call 1 (self–call), we now sign it as well.
-    string memory sessionSignature1 =
-      _signAndEncodeRSV(SessionSig.hashCallWithReplayProtection(payload.calls[1], payload), sessionWallet);
-    string memory callSig1 = _explicitCallSignatureToJSON(0, sessionSignature1);
-    string[] memory callSignatures = new string[](2);
-    callSignatures[0] = callSig0;
-    callSignatures[1] = callSig1;
-
-    address[] memory explicitSigners = new address[](1);
-    explicitSigners[0] = sessionWallet.addr;
-    address[] memory implicitSigners = new address[](0);
-    bytes memory encodedSig =
-      PrimitivesRPC.sessionEncodeCallSignatures(vm, topology, callSignatures, explicitSigners, implicitSigners);
-
-    vm.expectRevert(SessionErrors.InvalidSelfCall.selector);
     sessionManager.recoverSapientSignature(payload, encodedSig);
   }
 
@@ -532,25 +427,361 @@ contract SessionManagerTest is SessionTestBase {
       behaviorOnError: Payload.BEHAVIOR_REVERT_ON_ERROR
     });
 
-    // Create the implicit call signature.
-    string memory callSignature = _createImplicitCallSignature(payload, 0, sessionWallet, identityWallet, attestation);
+    (bytes32 imageHash, bytes memory encodedSig) = _validImplicitSessionSignature(payload);
 
-    // Build the session topology for implicit sessions.
+    vm.prank(sessionWallet.addr);
+    bytes32 actualImageHash = sessionManager.recoverSapientSignature(payload, encodedSig);
+    assertEq(imageHash, actualImageHash);
+  }
+
+  /// @notice Test that calls with onlyFallback = true are allowed
+  function testOnlyFallbackCallsAllowed() public {
+    // Build a payload with one call that has onlyFallback = true
+    Payload.Decoded memory payload = _buildPayload(1);
+    payload.calls[0] = Payload.Call({
+      to: address(emitter), // Use emitter instead of explicitTarget for implicit sessions
+      value: 0,
+      data: abi.encodeWithSelector(Emitter.implicitEmit.selector),
+      gasLimit: 0,
+      delegateCall: false,
+      onlyFallback: true,
+      behaviorOnError: Payload.BEHAVIOR_REVERT_ON_ERROR
+    });
+
+    (bytes32 imageHash, bytes memory encodedSig) = _validImplicitSessionSignature(payload);
+
+    vm.prank(sessionWallet.addr);
+    bytes32 actualImageHash = sessionManager.recoverSapientSignature(payload, encodedSig);
+    assertEq(imageHash, actualImageHash);
+  }
+
+  /// @notice Test that calls with BEHAVIOR_ABORT_ON_ERROR will revert with InvalidBehavior
+  function testBehaviorAbortOnErrorCallsRevert(address target, bytes memory data) public {
+    vm.assume(target != address(sessionManager));
+    // Build a payload with one call that has BEHAVIOR_ABORT_ON_ERROR
+    uint256 callCount = 1;
+    Payload.Decoded memory payload = _buildPayload(callCount);
+    payload.calls[0] = Payload.Call({
+      to: target,
+      value: 0,
+      data: data,
+      gasLimit: 0,
+      delegateCall: false,
+      onlyFallback: false,
+      behaviorOnError: Payload.BEHAVIOR_ABORT_ON_ERROR // This should revert
+     });
+
+    (, bytes memory encodedSig) = _validImplicitSessionSignature(payload);
+
+    vm.expectRevert(SessionErrors.InvalidBehavior.selector);
+    sessionManager.recoverSapientSignature(payload, encodedSig);
+  }
+
+  /// @notice Test that calls with onlyFallback = true in explicit sessions are allowed
+  function testExplicitSessionOnlyFallbackAllowed(address target, bytes memory data) public {
+    vm.assume(target != address(sessionManager));
+    // Build a payload with two calls: explicit call + increment call
+    Payload.Decoded memory payload = _buildPayload(2);
+
+    // First call with onlyFallback = true (should be allowed)
+    payload.calls[0] = Payload.Call({
+      to: target,
+      value: 0,
+      data: data,
+      gasLimit: 0,
+      delegateCall: false,
+      onlyFallback: true,
+      behaviorOnError: Payload.BEHAVIOR_REVERT_ON_ERROR
+    });
+
+    // Second call (increment call)
+    payload.calls[1] = Payload.Call({
+      to: address(sessionManager),
+      value: 0,
+      data: abi.encodeWithSelector(sessionManager.incrementUsageLimit.selector, new UsageLimit[](0)),
+      gasLimit: 0,
+      delegateCall: false,
+      onlyFallback: false,
+      behaviorOnError: Payload.BEHAVIOR_REVERT_ON_ERROR
+    });
+
+    // Session permissions
+    SessionPermissions memory sessionPerms = SessionPermissions({
+      signer: sessionWallet.addr,
+      chainId: 0,
+      valueLimit: 0,
+      deadline: uint64(block.timestamp + 1 days),
+      permissions: new Permission[](1)
+    });
+    sessionPerms.permissions[0] = Permission({ target: target, rules: new ParameterRule[](0) });
+
+    uint8[] memory permissionIdxs = new uint8[](2);
+    permissionIdxs[0] = 0; // Call 0
+    permissionIdxs[1] = 0; // Call 1
+
+    (bytes32 imageHash, bytes memory encodedSig) = _validExplicitSessionSignature(payload, sessionPerms, permissionIdxs);
+
+    vm.prank(sessionWallet.addr);
+    bytes32 actualImageHash = sessionManager.recoverSapientSignature(payload, encodedSig);
+    assertEq(imageHash, actualImageHash);
+  }
+
+  /// @notice Test that the increment call cannot have onlyFallback = true
+  function testIncrementCallOnlyFallbackReverts(address target, bytes memory data) public {
+    vm.assume(target != address(sessionManager));
+    // Build a payload with two calls: explicit call + increment call with onlyFallback
+    uint256 callCount = 2;
+    Payload.Decoded memory payload = _buildPayload(callCount);
+
+    // First call (valid explicit call that will use usage limits)
+    payload.calls[0] = Payload.Call({
+      to: target,
+      value: 1, // Use some value to trigger usage tracking
+      data: data,
+      gasLimit: 0,
+      delegateCall: false,
+      onlyFallback: false,
+      behaviorOnError: Payload.BEHAVIOR_REVERT_ON_ERROR
+    });
+
+    // Second call (increment call with onlyFallback = true - should revert)
+    payload.calls[1] = Payload.Call({
+      to: address(sessionManager),
+      value: 0,
+      data: abi.encodeWithSelector(sessionManager.incrementUsageLimit.selector, new UsageLimit[](1)),
+      gasLimit: 0,
+      delegateCall: false,
+      onlyFallback: true, // This should cause the increment call to be skipped
+      behaviorOnError: Payload.BEHAVIOR_REVERT_ON_ERROR
+    });
+
+    // Session permissions with value limit to trigger usage tracking
+    SessionPermissions memory sessionPerms = SessionPermissions({
+      signer: sessionWallet.addr,
+      chainId: 0,
+      valueLimit: 1, // Set value limit to trigger usage tracking
+      deadline: uint64(block.timestamp + 1 days),
+      permissions: new Permission[](1)
+    });
+    sessionPerms.permissions[0] = Permission({ target: target, rules: new ParameterRule[](0) });
+
+    uint8[] memory permissionIdxs = new uint8[](2);
+    permissionIdxs[0] = 0; // Call 0
+    permissionIdxs[1] = 0; // Call 1
+
+    (, bytes memory encodedSig) = _validExplicitSessionSignature(payload, sessionPerms, permissionIdxs);
+
+    vm.expectRevert(SessionErrors.InvalidLimitUsageIncrement.selector);
+    sessionManager.recoverSapientSignature(payload, encodedSig);
+  }
+
+  /// @notice Test that calls with BEHAVIOR_IGNORE_ERROR in explicit sessions are allowed
+  function testExplicitSessionBehaviorIgnoreErrorAllowed(address target, bytes memory data) public {
+    vm.assume(target != address(sessionManager));
+    // Build a payload with two calls: explicit call with IGNORE_ERROR + increment call
+    uint256 callCount = 2;
+    Payload.Decoded memory payload = _buildPayload(callCount);
+
+    // First call with BEHAVIOR_IGNORE_ERROR (should be allowed)
+    payload.calls[0] = Payload.Call({
+      to: target,
+      value: 0,
+      data: data,
+      gasLimit: 0,
+      delegateCall: false,
+      onlyFallback: false,
+      behaviorOnError: Payload.BEHAVIOR_IGNORE_ERROR
+    });
+
+    // Second call (increment call)
+    payload.calls[1] = Payload.Call({
+      to: address(sessionManager),
+      value: 0,
+      data: abi.encodeWithSelector(sessionManager.incrementUsageLimit.selector, new UsageLimit[](0)),
+      gasLimit: 0,
+      delegateCall: false,
+      onlyFallback: false,
+      behaviorOnError: Payload.BEHAVIOR_REVERT_ON_ERROR
+    });
+
+    // Session permissions
+    SessionPermissions memory sessionPerms = SessionPermissions({
+      signer: sessionWallet.addr,
+      chainId: 0,
+      valueLimit: 0,
+      deadline: uint64(block.timestamp + 1 days),
+      permissions: new Permission[](1)
+    });
+    sessionPerms.permissions[0] = Permission({ target: target, rules: new ParameterRule[](0) });
+
+    uint8[] memory permissionIdxs = new uint8[](2);
+    permissionIdxs[0] = 0; // Call 0
+    permissionIdxs[1] = 0; // Call 1
+
+    (bytes32 imageHash, bytes memory encodedSig) = _validExplicitSessionSignature(payload, sessionPerms, permissionIdxs);
+
+    bytes32 actualImageHash = sessionManager.recoverSapientSignature(payload, encodedSig);
+    assertEq(imageHash, actualImageHash);
+  }
+
+  /// @notice Test that calls with BEHAVIOR_ABORT_ON_ERROR in explicit sessions revert
+  function testExplicitSessionBehaviorAbortOnErrorReverts(address target, bytes memory data) public {
+    vm.assume(target != address(sessionManager));
+    // Build a payload with two calls: explicit call with ABORT_ON_ERROR + increment call
+    uint256 callCount = 2;
+    Payload.Decoded memory payload = _buildPayload(callCount);
+
+    // First call with BEHAVIOR_ABORT_ON_ERROR (should revert)
+    payload.calls[0] = Payload.Call({
+      to: target,
+      value: 0,
+      data: data,
+      gasLimit: 0,
+      delegateCall: false,
+      onlyFallback: false,
+      behaviorOnError: Payload.BEHAVIOR_ABORT_ON_ERROR // This should revert
+     });
+
+    // Second call (increment call)
+    payload.calls[1] = Payload.Call({
+      to: address(sessionManager),
+      value: 0,
+      data: abi.encodeWithSelector(sessionManager.incrementUsageLimit.selector, new UsageLimit[](0)),
+      gasLimit: 0,
+      delegateCall: false,
+      onlyFallback: false,
+      behaviorOnError: Payload.BEHAVIOR_REVERT_ON_ERROR
+    });
+
+    // Session permissions
+    SessionPermissions memory sessionPerms = SessionPermissions({
+      signer: sessionWallet.addr,
+      chainId: 0,
+      valueLimit: 0,
+      deadline: uint64(block.timestamp + 1 days),
+      permissions: new Permission[](1)
+    });
+    sessionPerms.permissions[0] = Permission({ target: target, rules: new ParameterRule[](0) });
+
+    uint8[] memory permissionIdxs = new uint8[](2);
+    permissionIdxs[0] = 0; // Call 0
+    permissionIdxs[1] = 0; // Call 1
+
+    (, bytes memory encodedSig) = _validExplicitSessionSignature(payload, sessionPerms, permissionIdxs);
+
+    vm.expectRevert(SessionErrors.InvalidBehavior.selector);
+    sessionManager.recoverSapientSignature(payload, encodedSig);
+  }
+
+  /// @notice Test that valid linear execution still works
+  function testValidLinearExecution(address target, bytes memory data) public {
+    vm.assume(target != address(sessionManager));
+    // Build a payload with two calls: explicit call + increment call (both with valid flags)
+    uint256 callCount = 2;
+    Payload.Decoded memory payload = _buildPayload(callCount);
+
+    // First call (normal explicit call)
+    payload.calls[0] = Payload.Call({
+      to: target,
+      value: 0,
+      data: data,
+      gasLimit: 0,
+      delegateCall: false,
+      onlyFallback: false,
+      behaviorOnError: Payload.BEHAVIOR_REVERT_ON_ERROR // Valid behavior
+     });
+
+    // Second call (increment call with valid flags)
+    payload.calls[1] = Payload.Call({
+      to: address(sessionManager),
+      value: 0,
+      data: abi.encodeWithSelector(sessionManager.incrementUsageLimit.selector, new UsageLimit[](0)),
+      gasLimit: 0,
+      delegateCall: false,
+      onlyFallback: false, // Valid flag
+      behaviorOnError: Payload.BEHAVIOR_REVERT_ON_ERROR // Valid behavior
+     });
+
+    // Session permissions
+    SessionPermissions memory sessionPerms = SessionPermissions({
+      signer: sessionWallet.addr,
+      chainId: 0,
+      valueLimit: 0,
+      deadline: uint64(block.timestamp + 1 days),
+      permissions: new Permission[](1)
+    });
+    sessionPerms.permissions[0] = Permission({ target: target, rules: new ParameterRule[](0) });
+
+    uint8[] memory permissionIdxs = new uint8[](2);
+    permissionIdxs[0] = 0; // Call 0
+    permissionIdxs[1] = 0; // Call 1
+
+    (bytes32 imageHash, bytes memory encodedSig) = _validExplicitSessionSignature(payload, sessionPerms, permissionIdxs);
+
+    // This should succeed since all flags are valid for linear execution
+    bytes32 actualImageHash = sessionManager.recoverSapientSignature(payload, encodedSig);
+    assertEq(imageHash, actualImageHash);
+  }
+
+  // ============================================================================
+  // HELPER FUNCTIONS
+  // ============================================================================
+
+  /// @notice Create a valid attestation for testing
+  function _createValidAttestation() internal view returns (Attestation memory) {
+    Attestation memory attestation;
+    attestation.approvedSigner = sessionWallet.addr;
+    attestation.authData.redirectUrl = "https://example.com";
+    attestation.authData.issuedAt = uint64(block.timestamp);
+    return attestation;
+  }
+
+  function _validImplicitSessionSignature(
+    Payload.Decoded memory payload
+  ) internal returns (bytes32 imageHash, bytes memory encodedSig) {
     string memory topology = PrimitivesRPC.sessionEmpty(vm, identityWallet.addr);
-    string[] memory callSignatures = new string[](1);
-    callSignatures[0] = callSignature;
+    imageHash = PrimitivesRPC.sessionImageHash(vm, topology);
 
-    // Encode the full signature with the implicit flag set to true.
+    uint256 callCount = payload.calls.length;
+    string[] memory callSignatures = new string[](callCount);
+    Attestation memory attestation = _createValidAttestation();
+    for (uint256 i; i < callCount; i++) {
+      callSignatures[i] = _createImplicitCallSignature(payload, i, sessionWallet, identityWallet, attestation);
+    }
+
     address[] memory explicitSigners = new address[](0);
     address[] memory implicitSigners = new address[](1);
     implicitSigners[0] = sessionWallet.addr;
-    bytes memory encodedSig =
+    encodedSig =
+      PrimitivesRPC.sessionEncodeCallSignatures(vm, topology, callSignatures, explicitSigners, implicitSigners);
+    return (imageHash, encodedSig);
+  }
+
+  function _validExplicitSessionSignature(
+    Payload.Decoded memory payload,
+    SessionPermissions memory sessionPerms,
+    uint8[] memory permissionIdxs
+  ) internal returns (bytes32 imageHash, bytes memory encodedSig) {
+    string memory topology = PrimitivesRPC.sessionEmpty(vm, identityWallet.addr);
+    string memory sessionPermsJson = _sessionPermissionsToJSON(sessionPerms);
+    topology = PrimitivesRPC.sessionExplicitAdd(vm, sessionPermsJson, topology);
+    imageHash = PrimitivesRPC.sessionImageHash(vm, topology);
+
+    uint256 callCount = payload.calls.length;
+    string[] memory callSignatures = new string[](callCount);
+    for (uint256 i; i < callCount; i++) {
+      string memory sessionSignature =
+        _signAndEncodeRSV(SessionSig.hashCallWithReplayProtection(payload.calls[i], payload), sessionWallet);
+      callSignatures[i] = _explicitCallSignatureToJSON(permissionIdxs[i], sessionSignature);
+    }
+
+    address[] memory explicitSigners = new address[](1);
+    explicitSigners[0] = sessionWallet.addr;
+    address[] memory implicitSigners = new address[](0);
+    encodedSig =
       PrimitivesRPC.sessionEncodeCallSignatures(vm, topology, callSignatures, explicitSigners, implicitSigners);
 
-    // Validate the signature.
-    bytes32 imageHash = sessionManager.recoverSapientSignature(payload, encodedSig);
-    bytes32 expectedImageHash = PrimitivesRPC.sessionImageHash(vm, topology);
-    assertEq(imageHash, expectedImageHash);
+    return (imageHash, encodedSig);
   }
 
 }

--- a/test/extensions/sessions/explicit/ExplicitSessionManager.t.sol
+++ b/test/extensions/sessions/explicit/ExplicitSessionManager.t.sol
@@ -321,7 +321,7 @@ contract ExplicitSessionManagerTest is SessionTestBase {
     usage.limits = new UsageLimit[](0);
     usage.totalValueUsed = 0;
 
-    vm.expectRevert(SessionErrors.InvalidSelfCall.selector);
+    vm.expectRevert(SessionErrors.InvalidValue.selector);
     harness.validateExplicitCall(payload, 0, wallet, sessionWallet.addr, permsArr, 0, usage);
   }
 
@@ -583,6 +583,32 @@ contract ExplicitSessionManagerTest is SessionTestBase {
     SessionUsageLimits[] memory usageArr = new SessionUsageLimits[](1);
     usageArr[0] = usage;
 
+    vm.expectRevert(SessionErrors.InvalidLimitUsageIncrement.selector);
+    vm.prank(wallet);
+    harness.validateLimitUsageIncrement(incCall, usageArr);
+  }
+
+  function test_validateLimitUsageIncrement_OnlyFallbackAllowed() public {
+    // Prepare a call with correct target and behaviorOnError but onlyFallback = true
+    // This should revert because increment calls cannot be skippable
+    Payload.Call memory incCall = Payload.Call({
+      to: address(harness),
+      value: 0,
+      data: "invalid", // data is not checked because onlyFallback is wrong
+      gasLimit: 0,
+      delegateCall: false,
+      onlyFallback: true, // This should cause the increment call to be skipped
+      behaviorOnError: Payload.BEHAVIOR_REVERT_ON_ERROR
+    });
+
+    SessionUsageLimits memory usage;
+    usage.signer = sessionWallet.addr;
+    usage.limits = new UsageLimit[](0);
+    usage.totalValueUsed = 100;
+    SessionUsageLimits[] memory usageArr = new SessionUsageLimits[](1);
+    usageArr[0] = usage;
+
+    // This should revert because increment calls cannot have onlyFallback = true
     vm.expectRevert(SessionErrors.InvalidLimitUsageIncrement.selector);
     vm.prank(wallet);
     harness.validateLimitUsageIncrement(incCall, usageArr);

--- a/test/mocks/CanReenter.sol
+++ b/test/mocks/CanReenter.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.27;
+
+contract CanReenter {
+
+  function doAnotherCall(address target, bytes calldata data) external {
+    (bool success,) = target.call(data);
+    require(success, "Call failed");
+  }
+
+}

--- a/test/mocks/MockERC20.sol
+++ b/test/mocks/MockERC20.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.27;
+
+contract MockERC20 {
+
+  mapping(address => uint256) public balanceOf;
+  mapping(address => mapping(address => uint256)) public allowance;
+
+  uint256 public totalSupply;
+  string public name = "Mock Token";
+  string public symbol = "MOCK";
+  uint8 public decimals = 18;
+
+  event Transfer(address indexed from, address indexed to, uint256 value);
+  event Approval(address indexed owner, address indexed spender, uint256 value);
+
+  constructor() {
+    totalSupply = 1000000 * 10 ** decimals;
+    balanceOf[msg.sender] = totalSupply;
+  }
+
+  function transfer(address to, uint256 amount) external returns (bool) {
+    require(balanceOf[msg.sender] >= amount, "Insufficient balance");
+    balanceOf[msg.sender] -= amount;
+    balanceOf[to] += amount;
+    emit Transfer(msg.sender, to, amount);
+    return true;
+  }
+
+  function approve(address spender, uint256 amount) external returns (bool) {
+    allowance[msg.sender][spender] = amount;
+    emit Approval(msg.sender, spender, amount);
+    return true;
+  }
+
+  function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+    require(balanceOf[from] >= amount, "Insufficient balance");
+    require(allowance[from][msg.sender] >= amount, "Insufficient allowance");
+    balanceOf[from] -= amount;
+    balanceOf[to] += amount;
+    allowance[from][msg.sender] -= amount;
+    emit Transfer(from, to, amount);
+    return true;
+  }
+
+}


### PR DESCRIPTION
Replaces [https://github.com/0xsequence/wallet-contracts-v3/pull/62/files](https://github.com/0xsequence/wallet-contracts-v3/pull/62/files)

---

This PR aims to fix the SEQ-1 issue, caused by `BEHAVIOR_ABORT_ON_ERROR=ABORT` and `onlyFallback=true`, by explicitly forbidding these operations on the `incrementUsageLimit`.

It also aims to address the following reentrancy vulnerability, discovered while working on SEQ-1:

```
The core issue is a classic check-then-update race condition. The _validateExplicitCall function checks cumulative limits against the value in storage (getLimitUsage), but the corresponding incrementUsageLimit call only updates that storage value at the very end of the transaction batch. This creates a window where the contract's state is inconsistent between validation and execution. Here’s the attack flow:  

1. Initial state: A session has a cumulative limit of 1 ETH for token.transfer(). The limitUsage in storage is 0.
2. Attacker's payload: An attacker crafts a batch transaction with three calls:
    - Call 1: token.transfer(attacker, 1 ether) — uses the full limit for this transaction.
    - Call 2: A call to a malicious contract (CanReenter) which will immediately call back into the wallet's execute function with a second payload.
    - Call 3: The required incrementUsageLimit(1 ether) to finalize the usage for Call 1.
3. Execution (outer tx):
    - The session manager validates Call 1. The check is storage (0) + current call (1 ether) <= limit (1 ether). Passes.
    - The wallet begins executing the calls. Call 1 succeeds, and 1 ETH is transferred.
    - Call 2 executes, and the CanReenter contract re-enters the wallet.
4. Re-entrancy (inner tx):
    - The re-entrant payload executes another token.transfer(attacker, 0.5 ether).
    - The session manager validates this new call. It checks the limit by calling getLimitUsage(), which still reads 0 from storage because the outer transaction’s incrementUsageLimit hasn’t run yet.
    - The check is storage (0) + current call (0.5 ether) <= limit (1 ether). Passes.
    - The inner transaction executes, transferring an additional 0.5 ETH. Its own incrementUsageLimit call then runs, setting limitUsage in storage to 0.5 ether.
5. Execution resumes (outer tx):
    - The re-entrant call finishes.
    - Call 3 of the outer payload finally executes, calling incrementUsageLimit(1 ether). This overwrites the storage value, setting limitUsage to 1 ether.

Result: The attacker has successfully transferred 1.5 ETH, bypassing the 1 ETH limit. The final on-chain state incorrectly reports that only 1 ETH was used, completely hiding the re-entrant exploit.
```

This vulnerability is addressed by moving the call to `incrementUsageLimit` to the **start** of the transaction bundle. This ensures subsequent session limits are validated against the already incremented usage limit, in case of them being executed from within the batch itself.

Tests for the reentrancy scenario have also been added.