### PR TITLE
Add Reentrancy guard to calls

### DIFF
--- a/src/modules/Calls.sol
+++ b/src/modules/Calls.sol
@@ -6,11 +6,12 @@ import { Nonce } from "./Nonce.sol";
 import { Payload } from "./Payload.sol";
 import { BaseAuth } from "./auth/BaseAuth.sol";
 import { IDelegatedExtension } from "./interfaces/IDelegatedExtension.sol";
+import { ReentrancyGuard } from "./ReentrancyGuard.sol";
 
 /// @title Calls
 /// @author Agustin Aguilar, Michael Standen, William Hua
 /// @notice Contract for executing calls
-abstract contract Calls is BaseAuth, Nonce {
+abstract contract Calls is ReentrancyGuard, BaseAuth, Nonce {
 
   /// @notice Emitted when a call succeeds
   event CallSucceeded(bytes32 _opHash, uint256 _index);
@@ -31,7 +32,7 @@ abstract contract Calls is BaseAuth, Nonce {
   /// @notice Execute a call
   /// @param _payload The payload
   /// @param _signature The signature
-  function execute(bytes calldata _payload, bytes calldata _signature) external payable virtual {
+  function execute(bytes calldata _payload, bytes calldata _signature) external payable virtual nonReentrant {
     uint256 startingGas = gasleft();
     Payload.Decoded memory decoded = Payload.fromPackedCalls(_payload);
 

--- a/src/modules/ERC4337v07.sol
+++ b/src/modules/ERC4337v07.sol
@@ -2,11 +2,13 @@
 pragma solidity ^0.8.18;
 
 import { Calls } from "./Calls.sol";
+
+import { ReentrancyGuard } from "./ReentrancyGuard.sol";
 import { IAccount, PackedUserOperation } from "./interfaces/IAccount.sol";
 import { IERC1271_MAGIC_VALUE_HASH } from "./interfaces/IERC1271.sol";
 import { IEntryPoint } from "./interfaces/IEntryPoint.sol";
 
-abstract contract ERC4337v07 is IAccount, Calls {
+abstract contract ERC4337v07 is ReentrancyGuard, IAccount, Calls {
 
   uint256 internal constant SIG_VALIDATION_FAILED = 1;
 
@@ -49,7 +51,7 @@ abstract contract ERC4337v07 is IAccount, Calls {
 
   function executeUserOp(
     bytes calldata _payload
-  ) external {
+  ) external nonReentrant {
     if (entrypoint == address(0)) {
       revert ERC4337Disabled();
     }

--- a/src/modules/ReentrancyGuard.sol
+++ b/src/modules/ReentrancyGuard.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { Storage } from "./Storage.sol";
+
+abstract contract ReentrancyGuard {
+  bytes32 private constant _INITIAL_VALUE = bytes32(0);
+  bytes32 private constant _NOT_ENTERED = bytes32(uint256(1));
+  bytes32 private constant _ENTERED = bytes32(uint256(2));
+
+  /// @dev keccak256("org.sequence.module.reentrancyguard.status")
+  bytes32 private constant STATUS_KEY = bytes32(0xfc6e07e3992c7c3694a921dc9e412b6cfe475380556756a19805a9e3ddfe2fde);
+
+  /// @notice Error thrown when a reentrant call is detected
+  error ReentrantCall();
+
+  /// @notice Prevents a contract from calling itself, directly or indirectly
+  modifier nonReentrant() {
+    // On the first call to nonReentrant
+    // _status will be _NOT_ENTERED or _INITIAL_VALUE
+    if (Storage.readBytes32(STATUS_KEY) == _ENTERED) {
+      revert ReentrantCall();
+    }
+
+    // Any calls to nonReentrant after this point will fail
+    Storage.writeBytes32(STATUS_KEY, _ENTERED);
+
+    _;
+
+    // By storing the original value once again, a refund is triggered (see
+    // https://eips.ethereum.org/EIPS/eip-2200)
+    // Notice that because contructors are not available
+    // we always start with _INITIAL_VALUE, not _NOT_ENTERED
+    Storage.writeBytes32(STATUS_KEY, _NOT_ENTERED);
+  }
+}

--- a/src/modules/ReentrancyGuard.sol
+++ b/src/modules/ReentrancyGuard.sol
@@ -29,7 +29,7 @@ abstract contract ReentrancyGuard {
 
     // By storing the original value once again, a refund is triggered (see
     // https://eips.ethereum.org/EIPS/eip-2200)
-    // Notice that because contructors are not available
+    // Notice that because constructors are not available
     // we always start with _INITIAL_VALUE, not _NOT_ENTERED
     Storage.writeBytes32(STATUS_KEY, _NOT_ENTERED);
   }

--- a/test/Stage1Module.t.sol
+++ b/test/Stage1Module.t.sol
@@ -1155,14 +1155,22 @@ contract TestStage1Module is AdvTest {
     Stage1Auth(vars.wallet).recoverSapientSignature(params.payload, vars.parentedSignature);
   }
 
-  function test_forbid_reentrancy(uint16 _threshold, uint56 _checkpoint, uint8 _weight) external {
+  function test_forbid_reentrancy(
+    uint16 _threshold,
+    uint56 _checkpoint,
+    uint8 _weight,
+    uint256 _signerPk,
+    Payload.Decoded memory _innerPayload,
+    bool _outerNoChainId,
+    bool _innerNoChainId
+  ) external {
     CanReenter canReenter = new CanReenter();
     _weight = uint8(bound(_weight, 0, 255));
     _threshold = uint16(bound(_threshold, 0, _weight));
     _checkpoint = uint56(bound(_checkpoint, 0, type(uint56).max));
+    _signerPk = boundPk(_signerPk);
 
-    uint256 signerPk = boundPk(uint256(1));
-    address signer = vm.addr(signerPk);
+    address signer = vm.addr(_signerPk);
 
     string memory ce;
     ce = string(abi.encodePacked(ce, "signer:", vm.toString(signer), ":", vm.toString(_weight)));
@@ -1171,31 +1179,22 @@ contract TestStage1Module is AdvTest {
     address payable wallet = payable(factory.deploy(address(stage1Module), PrimitivesRPC.getImageHash(vm, config)));
 
     // Build the inner payload
-    Payload.Decoded memory innerPayload;
-    innerPayload.kind = Payload.KIND_TRANSACTIONS;
-    innerPayload.calls = new Payload.Call[](1);
-    innerPayload.space = 2;
-    innerPayload.calls[0] = Payload.Call({
-      to: address(1),
-      value: 0,
-      data: bytes(""),
-      gasLimit: 100000,
-      delegateCall: false,
-      onlyFallback: false,
-      behaviorOnError: Payload.BEHAVIOR_REVERT_ON_ERROR
-    });
+    _innerPayload.noChainId = _innerNoChainId;
+    _innerPayload.kind = Payload.KIND_TRANSACTIONS;
+    boundToLegalPayload(_innerPayload);
+
 
     // Sign the inner payload
-    (uint256 v, bytes32 r, bytes32 s) = vm.sign(signerPk, Payload.hashFor(innerPayload, address(wallet)));
+    (uint256 v, bytes32 r, bytes32 s) = vm.sign(_signerPk, Payload.hashFor(_innerPayload, address(wallet)));
     bytes memory innerSignature = PrimitivesRPC.toEncodedSignature(
       vm,
       config,
       string(abi.encodePacked(vm.toString(signer), ":hash:", vm.toString(r), ":", vm.toString(s), ":", vm.toString(v))),
-      true
+      !_innerNoChainId
     );
 
     // Pack the inner payload
-    bytes memory innerPackedPayload = PrimitivesRPC.toPackedPayload(vm, innerPayload);
+    bytes memory innerPackedPayload = PrimitivesRPC.toPackedPayload(vm, _innerPayload);
 
     // Build the outer payload
     Payload.Decoded memory outerPayload;
@@ -1215,13 +1214,15 @@ contract TestStage1Module is AdvTest {
       behaviorOnError: Payload.BEHAVIOR_REVERT_ON_ERROR
     });
 
+    outerPayload.noChainId = _outerNoChainId;
+
     // Sign the outer payload
-    (v, r, s) = vm.sign(signerPk, Payload.hashFor(outerPayload, address(wallet)));
+    (v, r, s) = vm.sign(_signerPk, Payload.hashFor(outerPayload, address(wallet)));
     bytes memory outerSignature = PrimitivesRPC.toEncodedSignature(
       vm,
       config,
       string(abi.encodePacked(vm.toString(signer), ":hash:", vm.toString(r), ":", vm.toString(s), ":", vm.toString(v))),
-      true
+      !_outerNoChainId
     );
 
     // Pack the outer payload
@@ -1230,6 +1231,70 @@ contract TestStage1Module is AdvTest {
     // Execute the outer payload
     vm.expectRevert();
     Stage1Module(wallet).execute(outerPackedPayload, outerSignature);
+  }
+
+  function test_send_many_transactions(
+    uint256 _pk,
+    uint8 _weight,
+    uint16 _threshold,
+    uint256 _checkpoint,
+    uint256 _transactionCount,
+    bool _noChainId
+  ) external {
+    _pk = boundPk(_pk);
+    _weight = uint8(bound(_weight, 0, 255));
+    _threshold = uint16(bound(_threshold, 0, _weight));
+    _checkpoint = uint56(bound(_checkpoint, 0, type(uint56).max));
+    _transactionCount = uint256(bound(_transactionCount, 2, 10));
+
+    address signer = vm.addr(_pk);
+
+    string memory ce;
+    ce = string(abi.encodePacked(ce, "signer:", vm.toString(signer), ":", vm.toString(_weight)));
+    string memory config = PrimitivesRPC.newConfig(vm, _threshold, _checkpoint, ce);
+    
+    address payable wallet = payable(factory.deploy(address(stage1Module), PrimitivesRPC.getImageHash(vm, config)));
+
+    // Send (i + 1) wei amount of ETH to address(100 + i)
+    vm.deal(wallet, 1 ether);
+
+    for (uint256 i = 0; i < _transactionCount; i++) {
+      // Construct the payload
+      Payload.Decoded memory payload;
+      payload.kind = Payload.KIND_TRANSACTIONS;
+      payload.calls = new Payload.Call[](1);
+      payload.calls[0] = Payload.Call({
+        to: address(uint160(100 + i)),
+        value: i + 1,
+        data: bytes(""),
+        gasLimit: 100000,
+        delegateCall: false,
+        onlyFallback: false,
+        behaviorOnError: Payload.BEHAVIOR_REVERT_ON_ERROR
+      });
+
+      payload.noChainId = _noChainId;
+      payload.nonce = i;
+
+      // Sign the payload
+      (uint256 v, bytes32 r, bytes32 s) = vm.sign(_pk, Payload.hashFor(payload, address(wallet)));
+      bytes memory signature = PrimitivesRPC.toEncodedSignature(
+        vm,
+        config,
+        string(abi.encodePacked(vm.toString(signer), ":hash:", vm.toString(r), ":", vm.toString(s), ":", vm.toString(v))),
+        !_noChainId
+      );
+
+      // Pack the payload
+      bytes memory packedPayload = PrimitivesRPC.toPackedPayload(vm, payload);
+
+      // Execute the payload
+      (bool success, ) = wallet.call{value: i + 1}(abi.encodeWithSelector(Stage1Module(wallet).execute.selector, packedPayload, signature));
+      assertTrue(success);
+
+      // Verify the balance of address(100 + i)
+      assertEq(address(uint160(100 + i)).balance, i + 1);
+    }
   }
 
   receive() external payable { }

--- a/test/Stage1Module.t.sol
+++ b/test/Stage1Module.t.sol
@@ -1155,11 +1155,7 @@ contract TestStage1Module is AdvTest {
     Stage1Auth(vars.wallet).recoverSapientSignature(params.payload, vars.parentedSignature);
   }
 
-  function test_forbid_reentrancy(
-    uint16 _threshold,
-    uint56 _checkpoint,
-    uint8 _weight
-  ) external {
+  function test_forbid_reentrancy(uint16 _threshold, uint56 _checkpoint, uint8 _weight) external {
     CanReenter canReenter = new CanReenter();
     _weight = uint8(bound(_weight, 0, 255));
     _threshold = uint16(bound(_threshold, 0, _weight));
@@ -1208,7 +1204,11 @@ contract TestStage1Module is AdvTest {
     outerPayload.calls[0] = Payload.Call({
       to: address(canReenter),
       value: 0,
-      data: abi.encodeWithSelector(CanReenter.doAnotherCall.selector, address(wallet), abi.encodeWithSelector(Stage1Module(wallet).execute.selector, innerPackedPayload, innerSignature)),
+      data: abi.encodeWithSelector(
+        CanReenter.doAnotherCall.selector,
+        address(wallet),
+        abi.encodeWithSelector(Stage1Module(wallet).execute.selector, innerPackedPayload, innerSignature)
+      ),
       gasLimit: 1000000,
       delegateCall: false,
       onlyFallback: false,

--- a/test/mocks/CanReenter.sol
+++ b/test/mocks/CanReenter.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.27;
+
+contract CanReenter {
+
+  function doAnotherCall(address target, bytes calldata data) external {
+    (bool success,) = target.call(data);
+    require(success, "Call failed");
+  }
+
+}


### PR DESCRIPTION
This is a general hardening measure against possible interactions between modules like the smart sessions module and the wallet itself. The wallet, by itself, shouldn't be able to gain any privileges using reentrancy, as anything that can be done using a signature can also be achieved using `selfExecute`.
