### PR TITLE
4337 execute

### DIFF
--- a/src/modules/ERC4337v07.sol
+++ b/src/modules/ERC4337v07.sol
@@ -6,13 +6,19 @@ import { IAccount, IAccountExecute, PackedUserOperation } from "./interfaces/IAc
 import { IERC1271_MAGIC_VALUE_HASH } from "./interfaces/IERC1271.sol";
 import { IEntryPoint } from "./interfaces/IEntryPoint.sol";
 
+/// @title ERC4337v07
+/// @author Agustin Aguilar, Michael Standen
+/// @notice ERC4337 v7 support
 abstract contract ERC4337v07 is IAccount, IAccountExecute, Calls {
 
   uint256 internal constant SIG_VALIDATION_FAILED = 1;
 
+  /// @notice The entrypoint address
   address public immutable entrypoint;
 
+  /// @notice Error thrown when the entrypoint is invalid
   error InvalidEntryPoint(address _entrypoint);
+  /// @notice Error thrown when the ERC4337 is disabled
   error ERC4337Disabled();
 
   constructor(
@@ -21,6 +27,7 @@ abstract contract ERC4337v07 is IAccount, IAccountExecute, Calls {
     entrypoint = _entrypoint;
   }
 
+  /// @inheritdoc IAccount
   function validateUserOp(
     PackedUserOperation calldata userOp,
     bytes32 userOpHash,
@@ -47,6 +54,7 @@ abstract contract ERC4337v07 is IAccount, IAccountExecute, Calls {
     return 0;
   }
 
+  /// @inheritdoc IAccountExecute
   function executeUserOp(PackedUserOperation calldata userOp, bytes32) external {
     if (entrypoint == address(0)) {
       revert ERC4337Disabled();

--- a/src/modules/ERC4337v07.sol
+++ b/src/modules/ERC4337v07.sol
@@ -27,20 +27,22 @@ abstract contract ERC4337v07 is IAccount, IAccountExecute, Calls {
     entrypoint = _entrypoint;
   }
 
+  modifier onlyEntrypoint() {
+    if (entrypoint == address(0)) {
+      revert ERC4337Disabled();
+    }
+    if (msg.sender != entrypoint) {
+      revert InvalidEntryPoint(msg.sender);
+    }
+    _;
+  }
+
   /// @inheritdoc IAccount
   function validateUserOp(
     PackedUserOperation calldata userOp,
     bytes32 userOpHash,
     uint256 missingAccountFunds
-  ) external returns (uint256 validationData) {
-    if (entrypoint == address(0)) {
-      revert ERC4337Disabled();
-    }
-
-    if (msg.sender != entrypoint) {
-      revert InvalidEntryPoint(msg.sender);
-    }
-
+  ) external onlyEntrypoint returns (uint256 validationData) {
     // userOp.nonce is validated by the entrypoint
 
     if (missingAccountFunds != 0) {
@@ -55,15 +57,7 @@ abstract contract ERC4337v07 is IAccount, IAccountExecute, Calls {
   }
 
   /// @inheritdoc IAccountExecute
-  function executeUserOp(PackedUserOperation calldata userOp, bytes32) external {
-    if (entrypoint == address(0)) {
-      revert ERC4337Disabled();
-    }
-
-    if (msg.sender != entrypoint) {
-      revert InvalidEntryPoint(msg.sender);
-    }
-
+  function executeUserOp(PackedUserOperation calldata userOp, bytes32) external onlyEntrypoint {
     this.selfExecute(userOp.callData);
   }
 

--- a/src/modules/ERC4337v07.sol
+++ b/src/modules/ERC4337v07.sol
@@ -58,7 +58,9 @@ abstract contract ERC4337v07 is IAccount, IAccountExecute, Calls {
 
   /// @inheritdoc IAccountExecute
   function executeUserOp(PackedUserOperation calldata userOp, bytes32) external onlyEntrypoint {
-    this.selfExecute(userOp.callData);
+    // Skip the first 4 bytes (executeUserOp selector) and pass only the actual payload
+    bytes calldata payload = userOp.callData[4:];
+    this.selfExecute(payload);
   }
 
 }

--- a/src/modules/ERC4337v07.sol
+++ b/src/modules/ERC4337v07.sol
@@ -2,11 +2,11 @@
 pragma solidity ^0.8.18;
 
 import { Calls } from "./Calls.sol";
-import { IAccount, PackedUserOperation } from "./interfaces/IAccount.sol";
+import { IAccount, IAccountExecute, PackedUserOperation } from "./interfaces/IAccount.sol";
 import { IERC1271_MAGIC_VALUE_HASH } from "./interfaces/IERC1271.sol";
 import { IEntryPoint } from "./interfaces/IEntryPoint.sol";
 
-abstract contract ERC4337v07 is IAccount, Calls {
+abstract contract ERC4337v07 is IAccount, IAccountExecute, Calls {
 
   uint256 internal constant SIG_VALIDATION_FAILED = 1;
 
@@ -47,9 +47,7 @@ abstract contract ERC4337v07 is IAccount, Calls {
     return 0;
   }
 
-  function executeUserOp(
-    bytes calldata _payload
-  ) external {
+  function executeUserOp(PackedUserOperation calldata userOp, bytes32) external {
     if (entrypoint == address(0)) {
       revert ERC4337Disabled();
     }
@@ -58,7 +56,7 @@ abstract contract ERC4337v07 is IAccount, Calls {
       revert InvalidEntryPoint(msg.sender);
     }
 
-    this.selfExecute(_payload);
+    this.selfExecute(userOp.callData);
   }
 
 }

--- a/src/modules/interfaces/IAccount.sol
+++ b/src/modules/interfaces/IAccount.sol
@@ -63,3 +63,18 @@ interface IAccount {
   ) external returns (uint256 validationData);
 
 }
+
+interface IAccountExecute {
+
+  /**
+   * Account may implement this execute method.
+   * passing this methodSig at the beginning of callData will cause the entryPoint to pass the full UserOp (and hash)
+   * to the account.
+   * The account should skip the methodSig, and use the callData (and optionally, other UserOp fields)
+   *
+   * @param userOp              - The operation that was just validated.
+   * @param userOpHash          - Hash of the user's request data.
+   */
+  function executeUserOp(PackedUserOperation calldata userOp, bytes32 userOpHash) external;
+
+}

--- a/test/integrations/modules/ERC4337v07/ERC4337Entrypoint.t.sol
+++ b/test/integrations/modules/ERC4337v07/ERC4337Entrypoint.t.sol
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.27;
+
+import { Factory, Wallet } from "src/Factory.sol";
+import { Stage1Module } from "src/Stage1Module.sol";
+import { Payload } from "src/modules/Payload.sol";
+import { IAccountExecute } from "src/modules/interfaces/IAccount.sol";
+
+import { Emitter } from "test/mocks/Emitter.sol";
+import { PrimitivesRPC } from "test/utils/PrimitivesRPC.sol";
+import { AdvTest, Vm } from "test/utils/TestUtils.sol";
+
+import { EntryPoint } from "account-abstraction/core/EntryPoint.sol";
+import { PackedUserOperation, UserOperationLib } from "account-abstraction/core/UserOperationLib.sol";
+
+contract IntegrationERC4337v07Test is AdvTest {
+
+  Factory public factory;
+  EntryPoint public entryPoint;
+  Stage1Module public stage1Module;
+  address payable public wallet;
+  string public walletConfig;
+  bytes32 public walletImageHash;
+  Vm.Wallet public signer;
+
+  function setUp() public {
+    factory = new Factory();
+    entryPoint = new EntryPoint();
+    stage1Module = new Stage1Module(address(factory), address(entryPoint));
+
+    // Basic wallet setup for most tests.
+    signer = vm.createWallet("signer");
+    walletConfig =
+      PrimitivesRPC.newConfig(vm, 1, 0, string(abi.encodePacked("signer:", vm.toString(signer.addr), ":1")));
+    walletImageHash = PrimitivesRPC.getImageHash(vm, walletConfig);
+  }
+
+  // --- Helper Functions ---
+
+  function hashRealUserOp(
+    PackedUserOperation calldata userOp
+  ) public pure returns (bytes32) {
+    return UserOperationLib.hash(userOp);
+  }
+
+  function predictWalletAddress(
+    bytes32 imageHash
+  ) public view returns (address) {
+    bytes memory code = abi.encodePacked(Wallet.creationCode, uint256(uint160(address(stage1Module))));
+    bytes32 initCodeHash = keccak256(code);
+
+    return address(uint160(uint256(keccak256(abi.encodePacked(hex"ff", address(factory), imageHash, initCodeHash)))));
+  }
+
+  // --- tests ---
+
+  function test_Entrypoint_happypath(
+    address beneficiary
+  ) external {
+    vm.assume(beneficiary != address(0));
+    beneficiary = boundNoPrecompile(beneficiary);
+    vm.assume(beneficiary.code.length == 0);
+
+    // Deploy the wallet
+    wallet = payable(factory.deploy(address(stage1Module), walletImageHash));
+
+    // Setup a mock contract to call.
+    Emitter emitter = new Emitter();
+
+    // Create a payload to call the emitter contract.
+    Payload.Decoded memory decodedPayload;
+    decodedPayload.kind = Payload.KIND_TRANSACTIONS;
+    decodedPayload.calls = new Payload.Call[](1);
+    decodedPayload.calls[0] = Payload.Call({
+      to: address(emitter),
+      value: 0,
+      data: abi.encodeWithSelector(Emitter.explicitEmit.selector),
+      gasLimit: 0,
+      delegateCall: false,
+      onlyFallback: false,
+      behaviorOnError: Payload.BEHAVIOR_REVERT_ON_ERROR
+    });
+
+    bytes memory packedPayload = PrimitivesRPC.toPackedPayload(vm, decodedPayload);
+
+    // Gas stuff
+    uint256 verificationGasLimit = 100_000;
+    uint256 callGasLimit = 100_000;
+    uint256 preVerificationGas = 100_000;
+    uint256 maxFeePerGas = block.basefee;
+    uint256 maxPriorityFeePerGas = block.basefee;
+    uint256 totalGasLimit = verificationGasLimit + callGasLimit + preVerificationGas;
+    vm.deal(wallet, totalGasLimit * (maxFeePerGas + maxPriorityFeePerGas));
+
+    // Construct the UserOp.
+    PackedUserOperation memory userOp;
+    userOp.callData = abi.encodePacked(IAccountExecute.executeUserOp.selector, packedPayload);
+    userOp.sender = wallet;
+    userOp.nonce = 0;
+    userOp.initCode = "";
+    userOp.accountGasLimits = bytes32(abi.encodePacked(uint128(verificationGasLimit), uint128(callGasLimit)));
+    userOp.preVerificationGas = preVerificationGas;
+    userOp.gasFees = bytes32(abi.encodePacked(uint128(maxPriorityFeePerGas), uint128(maxFeePerGas)));
+    userOp.paymasterAndData = "";
+
+    // Get the userOpHash that the EntryPoint will use by calling its getUserOpHash function
+    bytes32 userOpHash = entryPoint.getUserOpHash(userOp);
+
+    // Create a signature for the userOpHash using the wallet's signer config.
+    Payload.Decoded memory payload;
+    payload.kind = Payload.KIND_DIGEST;
+    payload.digest = userOpHash;
+    bytes32 payloadDigest = Payload.hashFor(payload, wallet);
+
+    // Create a signature for the userOpHash using the wallet's signer config.
+    (uint8 v, bytes32 r, bytes32 s) = vm.sign(signer, payloadDigest);
+    string memory signatures = string(
+      abi.encodePacked(vm.toString(signer.addr), ":hash:", vm.toString(r), ":", vm.toString(s), ":", vm.toString(v))
+    );
+    userOp.signature = PrimitivesRPC.toEncodedSignature(vm, walletConfig, signatures, true);
+
+    PackedUserOperation[] memory ops = new PackedUserOperation[](1);
+    ops[0] = userOp;
+
+    // Call the entrypoint.
+    vm.expectEmit(true, false, false, true, address(emitter));
+    emit Emitter.Explicit(wallet);
+    entryPoint.handleOps(ops, payable(beneficiary));
+  }
+
+  function test_Entrypoint_initcode(
+    address beneficiary
+  ) external {
+    vm.assume(beneficiary != address(0));
+    beneficiary = boundNoPrecompile(beneficiary);
+    vm.assume(beneficiary.code.length == 0);
+
+    // Setup a mock contract to call.
+    Emitter emitter = new Emitter();
+
+    address predictedWallet = predictWalletAddress(walletImageHash);
+
+    // Create a payload to call the emitter contract.
+    Payload.Decoded memory decodedPayload;
+    decodedPayload.kind = Payload.KIND_TRANSACTIONS;
+    decodedPayload.calls = new Payload.Call[](1);
+    decodedPayload.calls[0] = Payload.Call({
+      to: address(emitter),
+      value: 0,
+      data: abi.encodeWithSelector(Emitter.explicitEmit.selector),
+      gasLimit: 0,
+      delegateCall: false,
+      onlyFallback: false,
+      behaviorOnError: Payload.BEHAVIOR_REVERT_ON_ERROR
+    });
+
+    bytes memory packedPayload = PrimitivesRPC.toPackedPayload(vm, decodedPayload);
+
+    // Gas stuff
+    uint256 verificationGasLimit = 1_000_000;
+    uint256 callGasLimit = 100_000;
+    uint256 preVerificationGas = 100_000;
+    uint256 maxFeePerGas = block.basefee;
+    uint256 maxPriorityFeePerGas = block.basefee;
+    uint256 totalGasLimit = verificationGasLimit + callGasLimit + preVerificationGas;
+    vm.deal(predictedWallet, totalGasLimit * (maxFeePerGas + maxPriorityFeePerGas));
+
+    // Construct the UserOp.
+    PackedUserOperation memory userOp;
+    userOp.callData = abi.encodePacked(IAccountExecute.executeUserOp.selector, packedPayload);
+    userOp.sender = predictedWallet;
+    userOp.nonce = 0;
+    userOp.initCode = abi.encodePacked(
+      address(factory), abi.encodeWithSelector(Factory.deploy.selector, address(stage1Module), walletImageHash)
+    ); // Deploy args
+    userOp.accountGasLimits = bytes32(abi.encodePacked(uint128(verificationGasLimit), uint128(callGasLimit)));
+    userOp.preVerificationGas = preVerificationGas;
+    userOp.gasFees = bytes32(abi.encodePacked(uint128(maxPriorityFeePerGas), uint128(maxFeePerGas)));
+    userOp.paymasterAndData = "";
+
+    // Get the userOpHash that the EntryPoint will use by calling its getUserOpHash function
+    bytes32 userOpHash = entryPoint.getUserOpHash(userOp);
+
+    // Create a signature for the userOpHash using the wallet's signer config.
+    Payload.Decoded memory payload;
+    payload.kind = Payload.KIND_DIGEST;
+    payload.digest = userOpHash;
+    bytes32 payloadDigest = Payload.hashFor(payload, predictedWallet);
+
+    // Create a signature for the userOpHash using the wallet's signer config.
+    (uint8 v, bytes32 r, bytes32 s) = vm.sign(signer, payloadDigest);
+    string memory signatures = string(
+      abi.encodePacked(vm.toString(signer.addr), ":hash:", vm.toString(r), ":", vm.toString(s), ":", vm.toString(v))
+    );
+    userOp.signature = PrimitivesRPC.toEncodedSignature(vm, walletConfig, signatures, true);
+
+    PackedUserOperation[] memory ops = new PackedUserOperation[](1);
+    ops[0] = userOp;
+
+    // Call the entrypoint.
+    vm.expectEmit(true, false, false, true, address(emitter));
+    emit Emitter.Explicit(predictedWallet);
+    entryPoint.handleOps(ops, payable(beneficiary));
+  }
+
+}

--- a/test/modules/ERC4337v07.t.sol
+++ b/test/modules/ERC4337v07.t.sol
@@ -142,24 +142,30 @@ contract ERC4337v07Test is AdvTest {
 
   // --- executeUserOp Tests ---
 
-  function test_executeUserOp_reverts_if_disabled(
-    bytes calldata payload
-  ) public {
+  function test_executeUserOp_reverts_if_disabled(bytes calldata payload, bytes32 userOpHash) public {
     // Deploy a new wallet with 4337 disabled.
     Stage1Module moduleDisabled = new Stage1Module(address(factory), address(0));
     address payable walletDisabled = payable(factory.deploy(address(moduleDisabled), walletImageHash));
 
     vm.prank(address(entryPoint));
     vm.expectRevert(ERC4337v07.ERC4337Disabled.selector);
-    Stage1Module(walletDisabled).executeUserOp(payload);
+    PackedUserOperation memory userOp;
+    userOp.callData = payload;
+    Stage1Module(walletDisabled).executeUserOp(userOp, userOpHash);
   }
 
-  function test_executeUserOp_reverts_invalidEntryPoint(bytes calldata payload, address randomCaller) public {
+  function test_executeUserOp_reverts_invalidEntryPoint(
+    bytes calldata payload,
+    bytes32 userOpHash,
+    address randomCaller
+  ) public {
     vm.assume(randomCaller != address(entryPoint));
 
     vm.prank(randomCaller);
     vm.expectRevert(abi.encodeWithSelector(ERC4337v07.InvalidEntryPoint.selector, randomCaller));
-    Stage1Module(wallet).executeUserOp(payload);
+    PackedUserOperation memory userOp;
+    userOp.callData = payload;
+    Stage1Module(wallet).executeUserOp(userOp, userOpHash);
   }
 
   function test_executeUserOp_executes_payload() external {
@@ -188,7 +194,9 @@ contract ERC4337v07Test is AdvTest {
 
     // Execute the userOp via the entrypoint.
     vm.prank(address(entryPoint));
-    Stage1Module(wallet).executeUserOp(packedPayload);
+    PackedUserOperation memory userOp;
+    userOp.callData = packedPayload;
+    Stage1Module(wallet).executeUserOp(userOp, bytes32(0));
   }
 
 }

--- a/test/modules/ERC4337v07.t.sol
+++ b/test/modules/ERC4337v07.t.sol
@@ -6,12 +6,16 @@ import { Stage1Module } from "../../src/Stage1Module.sol";
 
 import { ERC4337v07 } from "../../src/modules/ERC4337v07.sol";
 import { Payload } from "../../src/modules/Payload.sol";
-import { IAccount, PackedUserOperation } from "../../src/modules/interfaces/IAccount.sol";
+import { IAccount, IAccountExecute, PackedUserOperation } from "../../src/modules/interfaces/IAccount.sol";
 import { IEntryPoint } from "../../src/modules/interfaces/IEntryPoint.sol";
 import { Emitter } from "../mocks/Emitter.sol";
 import { PrimitivesRPC } from "../utils/PrimitivesRPC.sol";
 import { AdvTest } from "../utils/TestUtils.sol";
 import { EntryPoint, IStakeManager } from "account-abstraction/core/EntryPoint.sol";
+import {
+  PackedUserOperation as RealPackedUserOperation,
+  UserOperationLib
+} from "account-abstraction/core/UserOperationLib.sol";
 
 contract ERC4337v07Test is AdvTest {
 
@@ -54,6 +58,30 @@ contract ERC4337v07Test is AdvTest {
       paymasterAndData: "",
       signature: _signature
     });
+  }
+
+  function hashUserOp(
+    PackedUserOperation memory userOp
+  ) public view returns (bytes32) {
+    // Convert types
+    RealPackedUserOperation memory realUserOp = RealPackedUserOperation({
+      sender: userOp.sender,
+      nonce: userOp.nonce,
+      initCode: userOp.initCode,
+      callData: userOp.callData,
+      accountGasLimits: userOp.accountGasLimits,
+      preVerificationGas: userOp.preVerificationGas,
+      gasFees: userOp.gasFees,
+      paymasterAndData: userOp.paymasterAndData,
+      signature: userOp.signature
+    });
+    return this.hashRealUserOp(realUserOp);
+  }
+
+  function hashRealUserOp(
+    RealPackedUserOperation calldata userOp
+  ) public pure returns (bytes32) {
+    return UserOperationLib.hash(userOp);
   }
 
   // --- validateUserOp Tests ---
@@ -150,7 +178,7 @@ contract ERC4337v07Test is AdvTest {
     vm.prank(address(entryPoint));
     vm.expectRevert(ERC4337v07.ERC4337Disabled.selector);
     PackedUserOperation memory userOp;
-    userOp.callData = payload;
+    userOp.callData = abi.encodePacked(IAccountExecute.executeUserOp.selector, payload);
     Stage1Module(walletDisabled).executeUserOp(userOp, userOpHash);
   }
 
@@ -164,7 +192,7 @@ contract ERC4337v07Test is AdvTest {
     vm.prank(randomCaller);
     vm.expectRevert(abi.encodeWithSelector(ERC4337v07.InvalidEntryPoint.selector, randomCaller));
     PackedUserOperation memory userOp;
-    userOp.callData = payload;
+    userOp.callData = abi.encodePacked(IAccountExecute.executeUserOp.selector, payload);
     Stage1Module(wallet).executeUserOp(userOp, userOpHash);
   }
 
@@ -195,8 +223,80 @@ contract ERC4337v07Test is AdvTest {
     // Execute the userOp via the entrypoint.
     vm.prank(address(entryPoint));
     PackedUserOperation memory userOp;
-    userOp.callData = packedPayload;
+    userOp.callData = abi.encodePacked(IAccountExecute.executeUserOp.selector, packedPayload);
     Stage1Module(wallet).executeUserOp(userOp, bytes32(0));
+  }
+
+  // --- end to end tests ---
+
+  function test_endToEnd_executeUserOp_executes_payload(
+    address beneficiary
+  ) external {
+    vm.assume(beneficiary != address(0));
+    beneficiary = boundNoPrecompile(beneficiary);
+    vm.assume(beneficiary.code.length == 0);
+
+    // Setup a mock contract to call.
+    Emitter emitter = new Emitter();
+
+    // Create a payload to call the emitter contract.
+    Payload.Decoded memory decodedPayload;
+    decodedPayload.kind = Payload.KIND_TRANSACTIONS;
+    decodedPayload.calls = new Payload.Call[](1);
+    decodedPayload.calls[0] = Payload.Call({
+      to: address(emitter),
+      value: 0,
+      data: abi.encodeWithSelector(Emitter.explicitEmit.selector),
+      gasLimit: 0,
+      delegateCall: false,
+      onlyFallback: false,
+      behaviorOnError: Payload.BEHAVIOR_REVERT_ON_ERROR
+    });
+
+    bytes memory packedPayload = PrimitivesRPC.toPackedPayload(vm, decodedPayload);
+
+    // Gas stuff
+    uint256 verificationGasLimit = 100_000;
+    uint256 callGasLimit = 100_000;
+    uint256 preVerificationGas = 100_000;
+    uint256 maxFeePerGas = block.basefee;
+    uint256 maxPriorityFeePerGas = block.basefee;
+    uint256 totalGasLimit = verificationGasLimit + callGasLimit + preVerificationGas;
+    vm.deal(wallet, totalGasLimit * (maxFeePerGas + maxPriorityFeePerGas));
+
+    // Construct the UserOp.
+    RealPackedUserOperation memory userOp;
+    userOp.callData = abi.encodePacked(IAccountExecute.executeUserOp.selector, packedPayload);
+    userOp.sender = wallet;
+    userOp.nonce = 0;
+    userOp.initCode = "";
+    userOp.accountGasLimits = bytes32(abi.encodePacked(uint128(verificationGasLimit), uint128(callGasLimit)));
+    userOp.preVerificationGas = preVerificationGas;
+    userOp.gasFees = bytes32(abi.encodePacked(uint128(maxPriorityFeePerGas), uint128(maxFeePerGas)));
+    userOp.paymasterAndData = "";
+
+    // Get the userOpHash that the EntryPoint will use by calling its getUserOpHash function
+    bytes32 userOpHash = entryPoint.getUserOpHash(userOp);
+
+    // Create a signature for the userOpHash using the wallet's signer config.
+    Payload.Decoded memory payload;
+    payload.kind = Payload.KIND_DIGEST;
+    payload.digest = userOpHash;
+    bytes32 payloadDigest = Payload.hashFor(payload, wallet);
+
+    // Create a signature for the userOpHash using the wallet's signer config.
+    (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerPk, payloadDigest);
+    string memory signatures =
+      string(abi.encodePacked(vm.toString(signer), ":hash:", vm.toString(r), ":", vm.toString(s), ":", vm.toString(v)));
+    userOp.signature = PrimitivesRPC.toEncodedSignature(vm, walletConfig, signatures, true);
+
+    RealPackedUserOperation[] memory ops = new RealPackedUserOperation[](1);
+    ops[0] = userOp;
+
+    // Call the entrypoint.
+    vm.expectEmit(true, false, false, true, address(emitter));
+    emit Emitter.Explicit(wallet);
+    entryPoint.handleOps(ops, payable(beneficiary));
   }
 
 }


### PR DESCRIPTION
Updates the 4337 module:
* Uses IAccountExecute: see [interface](https://github.com/eth-infinitism/account-abstraction/blob/v0.7.0/contracts/interfaces/IAccountExecute.sol) and [entrypoint usage](https://github.com/eth-infinitism/account-abstraction/blob/v0.7.0/contracts/core/EntryPoint.sol#L101)
* Add missing docstring. Consistent with the rest of the repo
* Moves `msg.sender` validation to modifier for maintainability
* Add end to end tests using entrypoint