### PR TITLE
Block wallet self calls with sessions

### DIFF
--- a/src/extensions/sessions/SessionManager.sol
+++ b/src/extensions/sessions/SessionManager.sol
@@ -58,6 +58,10 @@ contract SessionManager is ISapient, ImplicitSessionManager, ExplicitSessionMana
       if (call.delegateCall) {
         revert SessionErrors.InvalidDelegateCall();
       }
+      // Ban self calls to the wallet
+      if (call.to == wallet) {
+        revert SessionErrors.InvalidSelfCall();
+      }
 
       // Check if this call could cause usage limits to be skipped
       if (call.behaviorOnError == Payload.BEHAVIOR_ABORT_ON_ERROR) {

--- a/test/extensions/sessions/SessionManager.t.sol
+++ b/test/extensions/sessions/SessionManager.t.sol
@@ -459,6 +459,7 @@ contract SessionManagerTest is SessionTestBase {
     uint256 value2,
     uint256 ruleValue
   ) public {
+    vm.assume(target != wallet);
     startIncrement = bound(startIncrement, 0, 1 ether);
     value1 = bound(value1, 1, 1 ether);
     value2 = bound(value2, 1, 1 ether);

--- a/test/integrations/extensions/sessions/SessionSelfCall.t.sol
+++ b/test/integrations/extensions/sessions/SessionSelfCall.t.sol
@@ -5,7 +5,7 @@ import { ExtendedSessionTestBase, Vm } from "./ExtendedSessionTestBase.sol";
 import { PrimitivesRPC } from "test/utils/PrimitivesRPC.sol";
 
 import { Stage1Module } from "src/Stage1Module.sol";
-import { SessionManager, SessionPermissions, SessionSig } from "src/extensions/sessions/SessionManager.sol";
+import { SessionErrors, SessionPermissions } from "src/extensions/sessions/SessionManager.sol";
 import { ParameterRule, Permission } from "src/extensions/sessions/explicit/Permission.sol";
 
 import { Payload } from "src/modules/Payload.sol";
@@ -65,6 +65,7 @@ contract IntegrationSessionSelfCall is ExtendedSessionTestBase {
 
     // Execute the self call payload
     bytes memory packedPayload = PrimitivesRPC.toPackedPayload(vm, payload);
+    vm.expectRevert(abi.encodeWithSelector(SessionErrors.InvalidSelfCall.selector));
     wallet.execute(packedPayload, signature);
   }
 


### PR DESCRIPTION
This prevents an explicit session using a permission to access the wallet and perform calls the require onlySelf permissions. 