### PR TITLE
Mock sapient

### DIFF
--- a/script/DeployMocks.s.sol
+++ b/script/DeployMocks.s.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.27;
 import { SingletonDeployer, console } from "lib/erc2470-libs/script/SingletonDeployer.s.sol";
 
 import { Emitter } from "test/mocks/Emitter.sol";
+import { MockSapient } from "test/mocks/MockSapient.sol";
 
 contract DeployMocks is SingletonDeployer {
 
@@ -14,6 +15,9 @@ contract DeployMocks is SingletonDeployer {
 
     bytes memory initCode = abi.encodePacked(type(Emitter).creationCode);
     _deployIfNotAlready("Emitter", initCode, salt, pk);
+
+    initCode = abi.encodePacked(type(MockSapient).creationCode);
+    _deployIfNotAlready("MockSapient", initCode, salt, pk);
   }
 
 }

--- a/test/mocks/MockSapient.sol
+++ b/test/mocks/MockSapient.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.27;
+
+import { ISapient } from "../../src/modules/interfaces/ISapient.sol";
+import { ISapientCompact } from "../../src/modules/interfaces/ISapient.sol";
+import { Payload } from "../../src/modules/Payload.sol";
+
+/// @title MockSapient
+/// @author Michael Standen
+/// @notice A mock sapient signer that returns the signature as the image hash
+contract MockSapient is ISapient, ISapientCompact {
+
+  error InvalidSignatureLength();
+
+  /// @inheritdoc ISapient
+  function recoverSapientSignature(Payload.Decoded calldata, bytes calldata signature) external pure returns (bytes32) {
+    if (signature.length != 32) {
+      revert InvalidSignatureLength();
+    }
+    return bytes32(signature);
+  }
+
+  /// @inheritdoc ISapientCompact
+  function recoverSapientSignatureCompact(bytes32, bytes calldata signature) external pure returns (bytes32) {
+    if (signature.length != 32) {
+      revert InvalidSignatureLength();
+    }
+    return bytes32(signature);
+  }
+
+}


### PR DESCRIPTION
Deploy a mock sapient signer for testing purposes. 

```
forge script ./script/DeployMocks.s.sol --rpc-url https://nodes.sequence.app/base --verify --etherscan-api-key <your_api_key> --broadcast
```

This deploys to `0xcd868A0F1b797fc8c6c0393dBA29687a83979E44` on any chain. 