### PR TITLE
x402 session sapient signer

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,6 +83,8 @@ jobs:
           node-version: ${{ matrix.setup_version }}
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: v1.5.1
       - name: Install Foundry Dependencies
         run: forge install
       - name: Run Build Server

--- a/docs/X402_SMART_SESSIONS.md
+++ b/docs/X402_SMART_SESSIONS.md
@@ -9,6 +9,8 @@ The signer has two validation paths that both return `hashPolicy(policy)`:
 
 The wallet configuration commits to the policy root once. That policy can authorize both x402 payments and the setup transaction needed to approve Permit2 for the policy token.
 
+Payments are organized as a policy-specific Permit2 nonce tape. A moving acceptance mask slides over that tape as `block.timestamp` advances. Consumed Permit2 bits stay consumed forever, but capacity renews because the mask moves onto fresh nonce positions.
+
 ```
                  payload.kind
                        │
@@ -71,7 +73,7 @@ For a payment digest, the x402 sapient signer:
       │
       ├─ 1. reconstruct the canonical Permit2 digest
       ├─ 2. require  digest == payload.digest
-      ├─ 3. policy limits: token · amount · nonce slot · expiry · chain
+      ├─ 3. policy limits: token · amount · nonce tape index · expiry · chain
       ├─ 4. session-key sig over (wallet, policyRoot, digest)
       │
       ▼
@@ -172,6 +174,9 @@ struct Policy {
   uint256 chainId;
   address token;
   uint256 maxAmountPerPayment;
+  uint64 windowStart;
+  uint64 windowDuration;
+  uint32 maxWindows;
   uint16 maxPayments;
   uint256 validBefore;
 }
@@ -205,23 +210,50 @@ The maximum allowed Permit2 `permitted.amount` for one payment.
 
 For x402 `exact`, this is the exact payment amount being authorized. The signer rejects zero amounts and amounts above this cap.
 
+#### `windowStart`
+
+The anchor timestamp for tape position `0`, and the policy's effective `validFrom`.
+
+The signer reverts any payment whose settlement block is before `windowStart`.
+
+#### `windowDuration`
+
+The time over which the full `maxPayments` capacity refills, in seconds.
+
+At `windowStart`, the live nonce mask is `[0, maxPayments - 1]`. Over one `windowDuration`, the mask advances by `maxPayments` positions. For example, with `maxPayments = 24` and `windowDuration = 24 hours`, one new nonce position becomes live about every hour.
+
+The refill math is integer-rounded:
+
+```
+minNonceIndex = (block.timestamp - windowStart) * maxPayments / windowDuration
+maxNonceIndex = minNonceIndex + maxPayments - 1
+```
+
+`windowDuration` must be greater than zero.
+
+#### `maxWindows`
+
+The optional lifetime cap, measured in full refill windows.
+
+If `maxWindows != 0`, the policy can use at most `maxWindows * maxPayments` tape positions. Once the moving mask has slid past the last position, payments revert with `RefillWindowsExhausted`. If `maxWindows == 0`, the policy is open-ended and bounded only by `validBefore` and revocation.
+
 #### `maxPayments`
 
-The number of allowed Permit2 nonce slots in the policy's deterministic nonce word.
+The number of live Permit2 nonce positions in the moving acceptance mask.
 
-The signer derives a Permit2 unordered nonce word from the wallet and policy root. The low 8 bits of the Permit2 nonce are treated as a slot index. The payment is valid only if:
+The signer accepts exactly this many logical nonce positions at a time:
 
 ```
-uint8(payment.nonce) < maxPayments
+minNonceIndex <= nonceIndex <= maxNonceIndex
 ```
 
-`maxPayments` must be greater than zero and at most `256`.
+`maxPayments` must be greater than zero. It is a `uint16`, so the maximum expressible value is `65535`. Unlike a single Permit2 word, the sliding mask can span many Permit2 words.
 
 #### `validBefore`
 
-The policy expiry timestamp.
+The hard backstop expiry for the whole policy.
 
-The signer rejects the policy after `validBefore`. Individual Permit2 `deadline` and x402 witness `validAfter` remain part of the payment digest and are enforced by Permit2 and the x402 proxy during settlement.
+The signer rejects the policy after `validBefore`, independent of the window schedule. Individual Permit2 `deadline` and x402 witness `validAfter` remain part of the payment digest and are enforced by Permit2 and the x402 proxy during settlement.
 
 ---
 
@@ -253,7 +285,16 @@ The signer uses this field in `TokenPermissions(token, amount)` and enforces `am
 
 The Permit2 unordered nonce.
 
-The high 248 bits must equal the deterministic nonce word for `(signer, wallet, policyRoot)`. The low 8 bits select the payment slot and must be below `policy.maxPayments`.
+The signer treats Permit2 nonce space as a policy-specific linear tape:
+
+```
+Permit2 nonce = (word << 8) | bit
+word          = wordBase + wordOffset
+nonceIndex    = wordOffset * 256 + bit
+```
+
+The `word` must be inside the policy's reserved word range, and `nonceIndex` must be inside the moving acceptance
+mask at settlement time.
 
 #### `deadline`
 
@@ -395,7 +436,7 @@ The call must satisfy:
 
 The signer checks `call.to == policy.token`.
 
-This approval does not spend funds by itself. It grants Permit2 allowance for the same token the policy can later spend through x402. The later payment path still requires a valid x402 Permit2 digest, policy root, session key signature, amount cap, nonce slot, and token match.
+This approval does not spend funds by itself. It grants Permit2 allowance for the same token the policy can later spend through x402. The later payment path still requires a valid x402 Permit2 digest, policy root, session key signature, amount cap, nonce word/range, and token match.
 
 ```
   wallet.execute(packedCalls, sequenceSignature)
@@ -479,54 +520,91 @@ For approval setup, `payloadDigest` is `Payload.hashFor(payload, wallet)`, so th
 
 ---
 
-## 10. Deterministic Permit2 Nonce Word
+## 10. Sliding Permit2 Nonce Tape
 
-Permit2 unordered nonces are partitioned into 248-bit words with 8-bit slots. The signer reserves one deterministic nonce word per wallet and policy:
-
-```
-permit2NonceWord(wallet, policyRoot) =
-  uint256(
-    keccak256(
-      abi.encode(
-        PERMIT2_NONCE_WORD_TYPEHASH,
-        address(this),
-        wallet,
-        policyRoot
-      )
-    )
-  ) >> 8
-```
-
-The payment nonce must satisfy:
+Permit2 unordered nonces are partitioned into 248-bit words with 8-bit bits/slots:
 
 ```
-payment.nonce >> 8 == permit2NonceWord(wallet, policyRoot)
-uint8(payment.nonce) < policy.maxPayments
+Permit2 nonce = (word << 8) | bit
 ```
 
-This gives each `(signer, wallet, policy)` tuple its own Permit2 nonce namespace without adding a nonce word field to the policy.
+The signer interprets those words as a policy-specific linear tape:
 
 ```
-  256-bit Permit2 nonce
-  ┌──────────────────────────────────────────────────┬───────────┐
-  │ word = nonce >> 8                     (248 bits) │ slot (8b) │
-  └──────────────────────────────────────────────────┴───────────┘
-        │                                            │
-        │ must equal                                 │ must be < maxPayments
-        ▼                                            ▼
-  permit2NonceWord(wallet, policyRoot)         slot ∈ [0, maxPayments)
-   = keccak( PERMIT2_NONCE_WORD_TYPEHASH,
-             address(this), wallet, policyRoot ) >> 8
-
-  Permit2 unordered-nonce bitmap for that word — one bit per payment:
-
-     slot     0    1    2    3   ···  maxPayments-1        255
-            ┌────┬────┬────┬────┬─   ─┬──────────────┬─   ─┬─────┐
-            │ ██ │ ██ │    │    │ ··· │              │ ··· │  ×  │
-            └────┴────┴────┴────┴─   ─┴──────────────┴─   ─┴─────┘
-               ▲    ▲          └──── usable ────┘     └ rejected (slot ≥ maxPayments)
-               consumed by settled payments
+full Permit2 nonce = [ 184-bit wordBase ][ 64-bit wordOffset ][ 8-bit bitIndex ]
+Permit2 word       = wordBase + wordOffset
+nonceIndex         = wordOffset * 256 + bitIndex
 ```
+
+The base word is deterministic and aligned to reserve 64 low bits for the moving tape offset:
+
+```
+wordBase = (
+  keccak(
+    PERMIT2_NONCE_WORD_BASE_TYPEHASH,
+    address(this),
+    policyRoot
+  ) >> (256 - 184)
+) << 64
+```
+
+The signer derives payment nonces from that base:
+
+```
+word  = wordBase + (nonceIndex / 256)
+nonce = (word << 8) | uint8(nonceIndex)
+```
+
+Using the hash as the raw word offset would require modulo wraparound or could overflow Permit2's 248-bit word space
+when the hash lands near the top. Aligning the hash-derived base keeps the offset form, while guaranteeing room for
+`2^64` Permit2 words of tape:
+
+```
+wordBase <= word <= wordBase + type(uint64).max
+```
+
+The typehash includes the signer and policy root:
+
+```
+PERMIT2_NONCE_WORD_BASE_TYPEHASH,
+  address(this),
+  policyRoot
+```
+
+`wallet` is not part of the nonce derivation. Permit2 scopes nonce consumption by owner, and the session-key
+authorization still commits to the wallet.
+
+The moving acceptance mask is derived from settlement time:
+
+```
+minNonceIndex = (block.timestamp - windowStart) * maxPayments / windowDuration
+maxNonceIndex = minNonceIndex + maxPayments - 1
+```
+
+If `maxWindows != 0`, `maxNonceIndex` is capped to:
+
+```
+maxWindows * maxPayments - 1
+```
+
+A payment nonce is valid only if:
+
+```
+wordBase <= word <= wordBase + type(uint64).max
+minNonceIndex <= nonceIndex <= maxNonceIndex
+```
+
+This is the "sliding mask over a tape" model:
+
+```
+time T:      [  0   1   2   3   4 ]                         maxPayments = 5
+time T + q:      [  1   2   3   4   5 ]
+time T + 2q:         [  2   3   4   5   6 ]
+
+q = windowDuration / maxPayments, rounded by integer division in the formula above
+```
+
+Consumed Permit2 bits never clear. Capacity returns because the accepted range moves onto fresh tape positions. A facilitator should use the oldest live nonce positions first if it wants capacity to refill as soon as possible.
 
 ---
 
@@ -541,12 +619,15 @@ For `Payload.KIND_DIGEST`, it validates:
    - `token != address(0)`
    - `chainId == 0 || chainId == block.chainid`
    - `block.timestamp <= validBefore`
-   - `0 < maxPayments <= 256`
+   - `windowDuration != 0`
+   - `maxPayments != 0`
 2. The payment is in policy:
    - `amount > 0`
    - `amount <= maxAmountPerPayment`
-   - nonce word equals the deterministic policy nonce word
-   - nonce slot is below `maxPayments`
+   - `block.timestamp >= windowStart` (otherwise `WindowNotStarted`)
+   - the nonce word is inside the policy's reserved word range
+   - the linear nonce index is inside the current sliding mask
+   - the optional `maxWindows` lifetime cap has not been exhausted
 3. The reconstructed Permit2 digest equals `payload.digest`.
 4. The session key signature recovers `policy.sessionKey`.
 
@@ -600,9 +681,11 @@ The payment path enforces:
 - one token per policy
 - optional chain scoping
 - per-payment amount cap
-- maximum number of payments
-- policy expiry
-- deterministic Permit2 nonce namespace
+- a sliding refill schedule (`windowStart`, `windowDuration`)
+- maximum live tape positions (`maxPayments`)
+- optional lifetime cap (`maxWindows * maxPayments`)
+- policy backstop expiry (`validBefore`)
+- deterministic Permit2 nonce word base and moving accepted tape range
 - canonical x402 Permit2 digest reconstruction
 - wallet-bound session authorization
 
@@ -633,10 +716,10 @@ This signer does not enforce:
 The maximum stateless payment exposure for a policy is:
 
 ```
-maxPayments * maxAmountPerPayment
+maxWindows * maxPayments * maxAmountPerPayment
 ```
 
-This is an upper bound, not exact cumulative accounting.
+This is an upper bound, not exact cumulative accounting. When `maxWindows == 0` the policy is open-ended and bounded only by `validBefore` (and revocation), so lifetime exposure is unbounded over time.
 
 ---
 
@@ -662,9 +745,15 @@ An SDK creating a payment should:
 
 1. Build the policy and compute `policyRoot = hashPolicy(policy)`.
 2. Ensure the wallet configuration includes the sapient signer leaf for `policyRoot`.
-3. Derive `nonceWord = permit2NonceWord(wallet, policyRoot)`.
-4. Choose an unused slot `slot < policy.maxPayments`.
-5. Build `nonce = (nonceWord << 8) | slot`.
+3. Determine the live tape range:
+
+   ```
+   minNonceIndex = (block.timestamp - windowStart) * maxPayments / windowDuration
+   maxNonceIndex = minNonceIndex + maxPayments - 1
+   ```
+
+4. Choose an unused `nonceIndex` inside that range. Prefer the lowest live index so capacity refills sooner.
+5. Build `nonce = permit2Nonce(policyRoot, nonceIndex)`.
 6. Construct the x402 Permit2 payment using:
    - token: `policy.token`
    - amount: payment amount
@@ -681,10 +770,18 @@ An SDK creating a payment should:
 
 ## 15. Limitations
 
-Because ERC-1271 validation is `view`, this signer cannot update a spend counter. It uses Permit2 nonce slots to bound payment count, not to sum exact spend.
+Because ERC-1271 validation is `view`, this signer cannot update a spend counter. It uses a moving Permit2 nonce mask to bound payment count, not to sum exact spend.
 
 For exact cumulative accounting, use a state-changing settlement path or a separate accounting mechanism. Examples include a custom settlement helper, an escrow, a delegation manager, or a policy that maps nonce buckets to fixed denominations.
 
 The signer also assumes the x402 Permit2 proxy enforces its own witness semantics during settlement. The signer reconstructs and approves the digest; it does not replace Permit2 or proxy settlement checks.
 
 The approval setup path only approves Permit2 at max allowance for `policy.token`. It does not approve the x402 proxy, facilitators, or arbitrary spenders. It also cannot be used to lower Permit2 allowance.
+
+### Sliding-window timing
+
+A payment must settle while its `nonceIndex` is still inside the live mask. If settlement is delayed until the mask has moved past that index, validation fails with `InvalidNonceTapeIndex`. Align each payment's Permit2 `deadline` with the expected mask lifetime, and have the facilitator settle promptly. There is no built-in grace for expired tape positions.
+
+### Cancellation
+
+Auto-renewing policies are open-ended when `maxWindows == 0`, so stopping future tape positions requires removing the sapient leaf from the wallet configuration. There is no cheap per-position cancel in a `view` signer. If mid-stream cancellation must be a non-configuration action, use a state-changing settlement module instead.

--- a/docs/X402_SMART_SESSIONS.md
+++ b/docs/X402_SMART_SESSIONS.md
@@ -9,6 +9,25 @@ The signer has two validation paths that both return `hashPolicy(policy)`:
 
 The wallet configuration commits to the policy root once. That policy can authorize both x402 payments and the setup transaction needed to approve Permit2 for the policy token.
 
+```
+                 payload.kind
+                       │
+        ┌──────────────┴──────────────┐
+        ▼                              ▼
+   KIND_DIGEST                    KIND_TRANSACTIONS
+   x402 payment                   approve(PERMIT2, max) setup
+        │                              │
+        ▼                              ▼
+   reconstruct & match            match the single approve
+   the Permit2 digest             call to policy.token
+        │                              │
+        └──────────────┬──────────────┘
+                       ▼
+              return hashPolicy(policy)
+       ── the sapient image hash the wallet
+          committed in its configuration ──
+```
+
 ---
 
 ## 1. Overview
@@ -34,6 +53,37 @@ For a payment digest, the x402 sapient signer:
 5. Checks the stateless policy limits.
 6. Verifies the session key signature over the wallet, policy root, and external digest.
 7. Returns the policy root as the sapient image hash.
+
+```
+  x402 facilitator
+      │
+      │ permitWitnessTransferFrom(owner = wallet, signature, …)
+      ▼
+  Permit2  ───────────►  consumes the unordered nonce  (word, slot)
+      │
+      │ isValidSignature(permit2Digest, sequenceSignature)
+      ▼
+  Sequence wallet  (ERC-1271)
+      │
+      │ Payload.fromDigest(permit2Digest) = KIND_DIGEST  ▸  BaseSig walks config
+      ▼
+  X402SessionSapientSigner.recoverSapientSignature
+      │
+      ├─ 1. reconstruct the canonical Permit2 digest
+      ├─ 2. require  digest == payload.digest
+      ├─ 3. policy limits: token · amount · nonce slot · expiry · chain
+      ├─ 4. session-key sig over (wallet, policyRoot, digest)
+      │
+      ▼
+  returns  policyRoot = hashPolicy(policy)
+      │
+      ▼
+  policyRoot == committed sapient leaf ?  ──no──►  bytes4(0)   (rejected)
+      │
+     yes
+      ▼
+  wallet returns 0x1626ba7e  ──►  Permit2 transfers the token to witnessTo
+```
 
 The returned policy root must match the sapient signer leaf committed in the wallet image hash. If it does not match, the wallet rejects the ERC-1271 signature.
 
@@ -286,6 +336,32 @@ TokenPermissions(address token,uint256 amount)
 Witness(address to,uint256 validAfter)
 ```
 
+```
+  tokenPermissionsHash = keccak( TOKEN_PERMISSIONS_TYPEHASH,
+                                 policy.token, payment.amount )
+
+  witnessHash          = keccak( WITNESS_TYPEHASH,
+                                 payment.witnessTo, payment.witnessValidAfter )
+        │
+        │  both feed into
+        ▼
+  structHash = keccak( PERMIT2_WITNESS_TRANSFER_TYPEHASH,
+                       tokenPermissionsHash,
+                       X402_PERMIT2_PROXY,        ◄─ the Permit2 spender
+                       payment.nonce,
+                       payment.deadline,
+                       witnessHash )
+        │
+        ▼
+  permit2Digest = keccak( 0x1901, permit2DomainSeparator, structHash )
+
+        where  permit2DomainSeparator =
+               keccak( EIP712Domain, keccak("Permit2"), block.chainid, PERMIT2 )
+        │
+        ▼
+  require  permit2Digest == payload.digest        ◄─ the ERC-1271 hash
+```
+
 If the reconstructed digest does not equal `payload.digest`, validation fails.
 
 ---
@@ -320,6 +396,25 @@ The call must satisfy:
 The signer checks `call.to == policy.token`.
 
 This approval does not spend funds by itself. It grants Permit2 allowance for the same token the policy can later spend through x402. The later payment path still requires a valid x402 Permit2 digest, policy root, session key signature, amount cap, nonce slot, and token match.
+
+```
+  wallet.execute(packedCalls, sequenceSignature)
+      │
+      │ consume (space, nonce)        [ space ≤ type(uint80).max - 1 ]
+      ▼
+  Sequence wallet  ▸  KIND_TRANSACTIONS  ▸  BaseSig walks config
+      │
+      ▼
+  X402SessionSapientSigner.recoverSapientSignature
+      │
+      ├─ exactly one call, call.to == policy.token
+      ├─ approve(PERMIT2, type(uint256).max)
+      ├─ no value · no delegatecall · no fallback · revert-on-error
+      ├─ session-key sig over Payload.hashFor(payload, wallet)
+      │
+      ▼
+  returns policyRoot  ──►  matches committed leaf  ──►  wallet runs the approve
+```
 
 ---
 
@@ -364,6 +459,24 @@ This binds the session key signature to:
 
 For approval setup, `payloadDigest` is `Payload.hashFor(payload, wallet)`, so the signature covers the target token, calldata, nonce, nonce space, and parent wallets.
 
+```
+  ┌─ payloadDigest ─────────────────────────────────────────────
+  │    KIND_DIGEST        →  canonical Permit2 witness digest
+  │    KIND_TRANSACTIONS  →  Payload.hashFor(payload, wallet)
+  └──────────────────────────────────────────────────────────────
+                          │  embedded as `payloadDigest`
+                          ▼
+  ┌─ session authorization ─────────────────────────────────────
+  │    domain:  "Sequence X402 Session" · v1 · chainId · this signer
+  │    struct:  X402SessionAuthorization(wallet, policyRoot,
+  │                                      payloadDigest)
+  │    authDigest = keccak( 0x1901, sessionDomainSeparator, struct )
+  └──────────────────────────────────────────────────────────────
+                          │  ECDSA.recover(authDigest, sessionSig)
+                          ▼
+                must equal  policy.sessionKey
+```
+
 ---
 
 ## 10. Deterministic Permit2 Nonce Word
@@ -392,6 +505,28 @@ uint8(payment.nonce) < policy.maxPayments
 ```
 
 This gives each `(signer, wallet, policy)` tuple its own Permit2 nonce namespace without adding a nonce word field to the policy.
+
+```
+  256-bit Permit2 nonce
+  ┌──────────────────────────────────────────────────┬───────────┐
+  │ word = nonce >> 8                     (248 bits) │ slot (8b) │
+  └──────────────────────────────────────────────────┴───────────┘
+        │                                            │
+        │ must equal                                 │ must be < maxPayments
+        ▼                                            ▼
+  permit2NonceWord(wallet, policyRoot)         slot ∈ [0, maxPayments)
+   = keccak( PERMIT2_NONCE_WORD_TYPEHASH,
+             address(this), wallet, policyRoot ) >> 8
+
+  Permit2 unordered-nonce bitmap for that word — one bit per payment:
+
+     slot     0    1    2    3   ···  maxPayments-1        255
+            ┌────┬────┬────┬────┬─   ─┬──────────────┬─   ─┬─────┐
+            │ ██ │ ██ │    │    │ ··· │              │ ··· │  ×  │
+            └────┴────┴────┴────┴─   ─┴──────────────┴─   ─┴─────┘
+               ▲    ▲          └──── usable ────┘     └ rejected (slot ≥ maxPayments)
+               consumed by settled payments
+```
 
 ---
 

--- a/docs/X402_SMART_SESSIONS.md
+++ b/docs/X402_SMART_SESSIONS.md
@@ -1,0 +1,555 @@
+# x402 Sapient Signer Documentation
+
+This document describes the `X402SessionSapientSigner` contract used to validate x402 Permit2 payments through Sequence wallet ERC-1271 signatures.
+
+The signer has two validation paths that both return `hashPolicy(policy)`:
+
+- x402 payment digests
+- Permit2 approval setup transactions for `policy.token`
+
+The wallet configuration commits to the policy root once. That policy can authorize both x402 payments and the setup transaction needed to approve Permit2 for the policy token.
+
+---
+
+## 1. Overview
+
+x402 Permit2 payments require a per-payment Permit2 witness transfer authorization. For a Sequence wallet, Permit2 verifies that authorization through the wallet's ERC-1271 path:
+
+```
+wallet.isValidSignature(permit2Digest, sequenceSignature)
+```
+
+The Sequence wallet wraps the external digest as `Payload.KIND_DIGEST` and validates the provided Sequence signature. If the signature includes an x402 sapient signer leaf, the wallet calls:
+
+```
+X402SessionSapientSigner.recoverSapientSignature(payload, sapientSignature)
+```
+
+For a payment digest, the x402 sapient signer:
+
+1. Requires `payload.kind == Payload.KIND_DIGEST`.
+2. Decodes the x402 session policy and payment metadata.
+3. Recomputes the canonical x402 Permit2 digest.
+4. Requires the recomputed digest to equal `payload.digest`.
+5. Checks the stateless policy limits.
+6. Verifies the session key signature over the wallet, policy root, and external digest.
+7. Returns the policy root as the sapient image hash.
+
+The returned policy root must match the sapient signer leaf committed in the wallet image hash. If it does not match, the wallet rejects the ERC-1271 signature.
+
+For setup, the same signer can validate this transaction shape:
+
+```
+policy.token.approve(PERMIT2, type(uint256).max)
+```
+
+The setup transaction is policy-bound and requires session-key intent over the exact wallet transaction payload. To prevent the same rule from being used to reduce or revoke allowance, the amount must be exactly `type(uint256).max`.
+
+---
+
+## 2. Contract Scope
+
+The implementation lives at:
+
+```
+src/extensions/x402/X402SessionSapientSigner.sol
+```
+
+It targets one payment method:
+
+- x402 `exact`
+- Permit2 witness transfer
+- configured Permit2 verifying contract
+- configured x402 Permit2 proxy as the Permit2 spender
+
+It targets one setup transaction:
+
+- a single call to `policy.token`
+- nonce space no greater than `type(uint80).max - 1`
+- calldata selector `approve(address,uint256)`
+- spender equal to the configured Permit2 contract
+- amount equal to `type(uint256).max`
+
+It does not implement:
+
+- EIP-3009 validation
+- ERC-7710 delegation validation
+- batch-settlement vouchers
+- stateful total spend accounting
+- recipient allowlists
+- resource or origin allowlists
+- arbitrary spender approvals
+
+Those features require additional contracts or a broader policy format.
+
+---
+
+## 3. Constructor Parameters
+
+The signer is deployed with two immutable addresses:
+
+```
+constructor(address permit2, address x402Permit2Proxy)
+```
+
+### `permit2`
+
+The Permit2 contract used as the EIP-712 verifying contract when reconstructing the payment digest.
+
+The setup path also requires ERC-20 approval calls to set this address as the spender.
+
+### `x402Permit2Proxy`
+
+The x402 Permit2 proxy used as the Permit2 `spender` in the signed payment digest.
+
+These values are immutable so they do not need to be carried inside every policy or payment signature.
+
+---
+
+## 4. Payment Policy
+
+The payment policy is the sapient image hash preimage for `Payload.KIND_DIGEST`. The wallet configuration commits to:
+
+```
+hashPolicy(policy)
+```
+
+### Encoding
+
+```
+struct Policy {
+  address sessionKey;
+  uint256 chainId;
+  address token;
+  uint256 maxAmountPerPayment;
+  uint16 maxPayments;
+  uint256 validBefore;
+}
+```
+
+### Fields
+
+#### `sessionKey`
+
+The key authorized to sign x402 payments for this policy.
+
+The sapient signer recovers this address from the session authorization signature. A zero session key is invalid.
+
+#### `chainId`
+
+The chain where the policy is valid.
+
+If `chainId == 0`, the policy is chain-agnostic. Otherwise, it must equal `block.chainid`.
+
+Permit2's EIP-712 domain already binds each payment digest to the current chain. This field exists to make the policy itself explicitly single-chain or multi-chain.
+
+#### `token`
+
+The ERC-20 token allowed by the payment policy.
+
+The payment metadata does not carry a token. The signer reconstructs the Permit2 digest using `policy.token`.
+
+#### `maxAmountPerPayment`
+
+The maximum allowed Permit2 `permitted.amount` for one payment.
+
+For x402 `exact`, this is the exact payment amount being authorized. The signer rejects zero amounts and amounts above this cap.
+
+#### `maxPayments`
+
+The number of allowed Permit2 nonce slots in the policy's deterministic nonce word.
+
+The signer derives a Permit2 unordered nonce word from the wallet and policy root. The low 8 bits of the Permit2 nonce are treated as a slot index. The payment is valid only if:
+
+```
+uint8(payment.nonce) < maxPayments
+```
+
+`maxPayments` must be greater than zero and at most `256`.
+
+#### `validBefore`
+
+The policy expiry timestamp.
+
+The signer rejects the policy after `validBefore`. Individual Permit2 `deadline` and x402 witness `validAfter` remain part of the payment digest and are enforced by Permit2 and the x402 proxy during settlement.
+
+---
+
+## 5. Payment Metadata
+
+The payment metadata is the minimum data needed to reconstruct the canonical x402 Permit2 digest and enforce the policy.
+
+### Encoding
+
+```
+struct Permit2Payment {
+  uint256 amount;
+  uint256 nonce;
+  uint256 deadline;
+  address witnessTo;
+  uint256 witnessValidAfter;
+}
+```
+
+### Fields
+
+#### `amount`
+
+The Permit2 permitted token amount.
+
+The signer uses this field in `TokenPermissions(token, amount)` and enforces `amount <= policy.maxAmountPerPayment`.
+
+#### `nonce`
+
+The Permit2 unordered nonce.
+
+The high 248 bits must equal the deterministic nonce word for `(signer, wallet, policyRoot)`. The low 8 bits select the payment slot and must be below `policy.maxPayments`.
+
+#### `deadline`
+
+The Permit2 permit deadline.
+
+The signer includes this field in the reconstructed Permit2 digest. It does not separately enforce the deadline because Permit2 enforces it when settling.
+
+#### `witnessTo`
+
+The x402 recipient encoded in the Permit2 witness.
+
+The signer does not restrict recipients. Any recipient is allowed by this policy shape.
+
+#### `witnessValidAfter`
+
+The x402 witness lower-bound timestamp.
+
+The signer includes this field in the reconstructed Permit2 digest. It does not separately enforce it because the x402 Permit2 proxy enforces the witness timing during settlement.
+
+---
+
+## 6. Sapient Signature
+
+The payment sapient signature passed to the signer for `Payload.KIND_DIGEST` is ABI-encoded as:
+
+```
+struct X402Signature {
+  Policy policy;
+  Permit2Payment payment;
+  bytes sessionKeySignature;
+}
+```
+
+There is no mode byte. The payload kind selects the validation path.
+
+The approval sapient signature passed to the signer for `Payload.KIND_TRANSACTIONS` is ABI-encoded as:
+
+```
+struct ApprovalSignature {
+  Policy policy;
+  bytes sessionKeySignature;
+}
+```
+
+The session key signs the wallet transaction payload hash, wrapped in the same session authorization type used by payments.
+
+---
+
+## 7. Permit2 Digest Reconstruction
+
+The signer reconstructs the canonical Permit2 digest from:
+
+- `policy.token`
+- `payment.amount`
+- `X402_PERMIT2_PROXY`
+- `payment.nonce`
+- `payment.deadline`
+- `payment.witnessTo`
+- `payment.witnessValidAfter`
+- `PERMIT2`
+- `block.chainid`
+
+The x402 witness type is:
+
+```
+Witness(address to,uint256 validAfter)
+```
+
+The Permit2 witness transfer type is:
+
+```
+PermitWitnessTransferFrom(
+  TokenPermissions permitted,
+  address spender,
+  uint256 nonce,
+  uint256 deadline,
+  Witness witness
+)
+TokenPermissions(address token,uint256 amount)
+Witness(address to,uint256 validAfter)
+```
+
+If the reconstructed digest does not equal `payload.digest`, validation fails.
+
+---
+
+## 8. Approval Transaction
+
+The approval path exists to let the wallet set Permit2 allowance without requiring a separate manual wallet signing flow.
+
+The transaction payload must contain exactly one call:
+
+```
+policy.token.approve(PERMIT2, type(uint256).max)
+```
+
+The transaction nonce space must be in the same reserved range used by smart sessions:
+
+```
+payload.space <= type(uint80).max - 1
+```
+
+The call must satisfy:
+
+- `call.value == 0`
+- `call.delegateCall == false`
+- `call.onlyFallback == false`
+- `call.behaviorOnError == Payload.BEHAVIOR_REVERT_ON_ERROR`
+- calldata length is exactly `68` bytes
+- calldata selector is `approve(address,uint256)`
+- decoded spender is `PERMIT2`
+- decoded amount is exactly `type(uint256).max`
+
+The signer checks `call.to == policy.token`.
+
+This approval does not spend funds by itself. It grants Permit2 allowance for the same token the policy can later spend through x402. The later payment path still requires a valid x402 Permit2 digest, policy root, session key signature, amount cap, nonce slot, and token match.
+
+---
+
+## 9. Session Authorization
+
+The session key does not sign raw external digests directly. It signs a Sequence x402 session authorization:
+
+```
+X402SessionAuthorization(
+  address wallet,
+  bytes32 policyRoot,
+  bytes32 payloadDigest
+)
+```
+
+The EIP-712 domain is:
+
+```
+EIP712Domain(
+  string name,
+  string version,
+  uint256 chainId,
+  address verifyingContract
+)
+```
+
+with:
+
+```
+name = "Sequence X402 Session"
+version = "1"
+chainId = block.chainid
+verifyingContract = address(this)
+```
+
+This binds the session key signature to:
+
+- the wallet currently being validated
+- the policy committed in the wallet configuration
+- the exact external x402 Permit2 digest or wallet transaction payload hash
+- this sapient signer contract and chain
+
+For approval setup, `payloadDigest` is `Payload.hashFor(payload, wallet)`, so the signature covers the target token, calldata, nonce, nonce space, and parent wallets.
+
+---
+
+## 10. Deterministic Permit2 Nonce Word
+
+Permit2 unordered nonces are partitioned into 248-bit words with 8-bit slots. The signer reserves one deterministic nonce word per wallet and policy:
+
+```
+permit2NonceWord(wallet, policyRoot) =
+  uint256(
+    keccak256(
+      abi.encode(
+        PERMIT2_NONCE_WORD_TYPEHASH,
+        address(this),
+        wallet,
+        policyRoot
+      )
+    )
+  ) >> 8
+```
+
+The payment nonce must satisfy:
+
+```
+payment.nonce >> 8 == permit2NonceWord(wallet, policyRoot)
+uint8(payment.nonce) < policy.maxPayments
+```
+
+This gives each `(signer, wallet, policy)` tuple its own Permit2 nonce namespace without adding a nonce word field to the policy.
+
+---
+
+## 11. Validation Rules
+
+During `recoverSapientSignature`, the signer first validates the payload kind.
+
+For `Payload.KIND_DIGEST`, it validates:
+
+1. The policy is structurally valid:
+   - `sessionKey != address(0)`
+   - `token != address(0)`
+   - `chainId == 0 || chainId == block.chainid`
+   - `block.timestamp <= validBefore`
+   - `0 < maxPayments <= 256`
+2. The payment is in policy:
+   - `amount > 0`
+   - `amount <= maxAmountPerPayment`
+   - nonce word equals the deterministic policy nonce word
+   - nonce slot is below `maxPayments`
+3. The reconstructed Permit2 digest equals `payload.digest`.
+4. The session key signature recovers `policy.sessionKey`.
+
+If all checks pass, the signer returns:
+
+```
+hashPolicy(policy)
+```
+
+For `Payload.KIND_TRANSACTIONS`, it validates:
+
+1. The policy is structurally valid.
+2. The nonce space is no greater than `type(uint80).max - 1`.
+3. The payload contains exactly one call.
+4. The call target is `policy.token`.
+5. The call cannot send ETH.
+6. The call cannot use delegatecall.
+7. The call cannot be fallback-only.
+8. The call must revert on error.
+9. The calldata must be exactly `approve(PERMIT2, type(uint256).max)`.
+10. The session key signature over `hashSessionAuthorization(wallet, policyRoot, Payload.hashFor(payload, wallet))` recovers `policy.sessionKey`.
+
+If all checks pass, the signer returns:
+
+```
+hashPolicy(policy)
+```
+
+---
+
+## 12. Wallet Configuration
+
+To enable x402 payments for a policy, the wallet configuration must include a sapient signer leaf for:
+
+```
+sapient = address(X402SessionSapientSigner)
+sapientImageHash = hashPolicy(policy)
+```
+
+The same leaf enables both payment validation and Permit2 approval setup for that policy. Revocation is performed by removing that sapient leaf from the wallet configuration.
+
+Changing any payment policy field changes the policy root. A signature for one policy does not validate against another policy root.
+
+---
+
+## 13. Security Properties
+
+The payment path enforces:
+
+- one session key per policy
+- one token per policy
+- optional chain scoping
+- per-payment amount cap
+- maximum number of payments
+- policy expiry
+- deterministic Permit2 nonce namespace
+- canonical x402 Permit2 digest reconstruction
+- wallet-bound session authorization
+
+The approval path enforces:
+
+- one session key per policy
+- one policy token
+- the smart-session nonce-space range
+- one approval call per transaction
+- Permit2 as the only spender
+- max allowance as the only allowed amount
+- no ETH transfer
+- no delegatecall
+- no fallback-only execution
+- revert-on-error execution
+
+The max-amount approval requirement is intentional. Allowing arbitrary amounts would also allow `approve(PERMIT2, 0)`, which can revoke or reduce Permit2 allowance through the same sapient leaf.
+
+This signer does not enforce:
+
+- cumulative token spend by exact value
+- recipient restrictions
+- merchant/resource restrictions
+- facilitator restrictions
+- revocation without a wallet configuration update
+- arbitrary spender approvals
+
+The maximum stateless payment exposure for a policy is:
+
+```
+maxPayments * maxAmountPerPayment
+```
+
+This is an upper bound, not exact cumulative accounting.
+
+---
+
+## 14. Integration Notes
+
+An SDK setting up Permit2 approval should:
+
+1. Build the policy and compute `policyRoot = hashPolicy(policy)`.
+2. Ensure the wallet configuration includes the sapient signer leaf for `policyRoot`.
+3. If Permit2 allowance is insufficient for `policy.token`, build a transaction payload containing:
+
+   ```
+   policy.token.approve(PERMIT2, type(uint256).max)
+   ```
+
+4. Set `payload.space <= type(uint80).max - 1`.
+5. Have the session key sign `hashSessionAuthorization(wallet, policyRoot, Payload.hashFor(payload, wallet))`.
+6. ABI-encode `ApprovalSignature(policy, sessionKeySignature)`.
+7. Embed that as the sapient signature in the Sequence transaction signature.
+8. Execute the approval transaction.
+
+An SDK creating a payment should:
+
+1. Build the policy and compute `policyRoot = hashPolicy(policy)`.
+2. Ensure the wallet configuration includes the sapient signer leaf for `policyRoot`.
+3. Derive `nonceWord = permit2NonceWord(wallet, policyRoot)`.
+4. Choose an unused slot `slot < policy.maxPayments`.
+5. Build `nonce = (nonceWord << 8) | slot`.
+6. Construct the x402 Permit2 payment using:
+   - token: `policy.token`
+   - amount: payment amount
+   - spender: configured x402 Permit2 proxy
+   - nonce: derived nonce
+   - deadline: Permit2 deadline
+   - witness: `Witness({to, validAfter})`
+7. Compute the canonical Permit2 digest.
+8. Have the session key sign `hashSessionAuthorization(wallet, policyRoot, permit2Digest)`.
+9. ABI-encode `X402Signature(policy, payment, sessionKeySignature)`.
+10. Embed that as the sapient signature in the Sequence signature.
+
+---
+
+## 15. Limitations
+
+Because ERC-1271 validation is `view`, this signer cannot update a spend counter. It uses Permit2 nonce slots to bound payment count, not to sum exact spend.
+
+For exact cumulative accounting, use a state-changing settlement path or a separate accounting mechanism. Examples include a custom settlement helper, an escrow, a delegation manager, or a policy that maps nonce buckets to fixed denominations.
+
+The signer also assumes the x402 Permit2 proxy enforces its own witness semantics during settlement. The signer reconstructs and approves the digest; it does not replace Permit2 or proxy settlement checks.
+
+The approval setup path only approves Permit2 at max allowance for `policy.token`. It does not approve the x402 proxy, facilitators, or arbitrary spenders. It also cannot be used to lower Permit2 allowance.

--- a/src/extensions/x402/X402SessionSapientSigner.sol
+++ b/src/extensions/x402/X402SessionSapientSigner.sol
@@ -1,0 +1,322 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.27;
+
+import { ECDSA } from "../../../lib/openzeppelin-contracts/contracts/utils/cryptography/ECDSA.sol";
+
+import { Payload } from "../../modules/Payload.sol";
+import { ISapient } from "../../modules/interfaces/ISapient.sol";
+
+/// @title X402SessionSapientSigner
+/// @notice Digest-aware sapient signer for x402 exact Permit2 payments.
+/// @dev The returned sapient image hash is the policy root committed in the wallet config.
+contract X402SessionSapientSigner is ISapient {
+
+  bytes4 public constant APPROVE_SELECTOR = bytes4(keccak256("approve(address,uint256)"));
+  uint256 public constant MAX_SPACE = type(uint80).max - 1;
+  uint16 public constant MAX_PERMIT2_NONCE_SLOTS = 256;
+
+  bytes32 public constant X402_POLICY_TYPEHASH = keccak256(
+    "X402SessionPolicy(address sessionKey,uint256 chainId,address token,uint256 maxAmountPerPayment,uint16 maxPayments,uint256 validBefore)"
+  );
+  bytes32 public constant PERMIT2_NONCE_WORD_TYPEHASH =
+    keccak256("SequenceX402Permit2NonceWord(address signer,address wallet,bytes32 policyRoot)");
+
+  bytes32 public constant PERMIT2_DOMAIN_TYPEHASH =
+    keccak256("EIP712Domain(string name,uint256 chainId,address verifyingContract)");
+  bytes32 public constant PERMIT2_NAME_HASH = keccak256("Permit2");
+  bytes32 public constant TOKEN_PERMISSIONS_TYPEHASH = keccak256("TokenPermissions(address token,uint256 amount)");
+  bytes32 public constant WITNESS_TYPEHASH = keccak256("Witness(address to,uint256 validAfter)");
+  bytes32 public constant PERMIT2_WITNESS_TRANSFER_TYPEHASH = keccak256(
+    "PermitWitnessTransferFrom(TokenPermissions permitted,address spender,uint256 nonce,uint256 deadline,Witness witness)TokenPermissions(address token,uint256 amount)Witness(address to,uint256 validAfter)"
+  );
+
+  bytes32 public constant SESSION_DOMAIN_TYPEHASH =
+    keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+  bytes32 public constant SESSION_DOMAIN_NAME_HASH = keccak256("Sequence X402 Session");
+  bytes32 public constant SESSION_DOMAIN_VERSION_HASH = keccak256("1");
+  bytes32 public constant SESSION_AUTHORIZATION_TYPEHASH =
+    keccak256("X402SessionAuthorization(address wallet,bytes32 policyRoot,bytes32 payloadDigest)");
+
+  address public immutable PERMIT2;
+  address public immutable X402_PERMIT2_PROXY;
+
+  struct Policy {
+    address sessionKey;
+    uint256 chainId;
+    address token;
+    uint256 maxAmountPerPayment;
+    uint16 maxPayments;
+    uint256 validBefore;
+  }
+
+  struct Permit2Payment {
+    uint256 amount;
+    uint256 nonce;
+    uint256 deadline;
+    address witnessTo;
+    uint256 witnessValidAfter;
+  }
+
+  struct X402Signature {
+    Policy policy;
+    Permit2Payment payment;
+    bytes sessionKeySignature;
+  }
+
+  struct ApprovalSignature {
+    Policy policy;
+    bytes sessionKeySignature;
+  }
+
+  error InvalidPayloadKind(uint8 kind);
+  error InvalidSessionKey();
+  error InvalidSessionToken();
+  error InvalidChainId(uint256 chainId, uint256 expected);
+  error SessionExpired(uint256 validBefore, uint256 currentTime);
+  error InvalidPermit2();
+  error InvalidApprovalCallsLength(uint256 length);
+  error InvalidApprovalCall();
+  error InvalidApprovalSelector(bytes4 selector);
+  error InvalidApprovalSpender(address spender, address expected);
+  error InvalidApprovalAmount(uint256 amount, uint256 expected);
+  error InvalidSpace(uint256 space);
+  error InvalidPaymentAmount(uint256 amount, uint256 maxAmount);
+  error InvalidMaxPayments(uint16 maxPayments, uint16 maxAllowed);
+  error InvalidNonceWord(uint256 word, uint256 expected);
+  error InvalidNonceSlot(uint256 slot, uint16 maxPayments);
+  error InvalidToken(address token, address expected);
+  error InvalidDigest(bytes32 expected, bytes32 actual);
+  error InvalidSessionKeySignature(address recovered, address expected);
+
+  constructor(
+    address permit2,
+    address x402Permit2Proxy
+  ) {
+    if (permit2 == address(0) || x402Permit2Proxy == address(0)) {
+      revert InvalidPermit2();
+    }
+    PERMIT2 = permit2;
+    X402_PERMIT2_PROXY = x402Permit2Proxy;
+  }
+
+  /// @inheritdoc ISapient
+  function recoverSapientSignature(
+    Payload.Decoded calldata payload,
+    bytes calldata signature
+  ) external view returns (bytes32 imageHash) {
+    if (payload.kind == Payload.KIND_DIGEST) {
+      return _recoverPaymentSignature(payload, signature);
+    }
+    if (payload.kind == Payload.KIND_TRANSACTIONS) {
+      return _recoverApprovalSignature(payload, signature);
+    }
+
+    revert InvalidPayloadKind(payload.kind);
+  }
+
+  function _recoverPaymentSignature(
+    Payload.Decoded calldata payload,
+    bytes calldata signature
+  ) internal view returns (bytes32 imageHash) {
+    X402Signature memory sig = abi.decode(signature, (X402Signature));
+    bytes32 policyRoot = hashPolicy(sig.policy);
+    address wallet = msg.sender;
+    _validatePolicy(sig.policy);
+    _validatePermit2Payment(sig.policy, sig.payment, wallet, policyRoot);
+
+    bytes32 expectedDigest = hashPermit2Payment(sig.policy, sig.payment);
+    if (expectedDigest != payload.digest) {
+      revert InvalidDigest(expectedDigest, payload.digest);
+    }
+
+    bytes32 authDigest = hashSessionAuthorization(wallet, policyRoot, payload.digest);
+    address recovered = ECDSA.recover(authDigest, sig.sessionKeySignature);
+    if (recovered != sig.policy.sessionKey) {
+      revert InvalidSessionKeySignature(recovered, sig.policy.sessionKey);
+    }
+
+    return policyRoot;
+  }
+
+  function _recoverApprovalSignature(
+    Payload.Decoded calldata payload,
+    bytes calldata signature
+  ) internal view returns (bytes32 imageHash) {
+    ApprovalSignature memory sig = abi.decode(signature, (ApprovalSignature));
+    bytes32 policyRoot = hashPolicy(sig.policy);
+    address wallet = msg.sender;
+    _validatePolicy(sig.policy);
+    _validateApprovalPayload(sig.policy, payload);
+
+    bytes32 payloadDigest = _payloadHashFor(payload, wallet);
+    bytes32 authDigest = hashSessionAuthorization(wallet, policyRoot, payloadDigest);
+    address recovered = ECDSA.recover(authDigest, sig.sessionKeySignature);
+    if (recovered != sig.policy.sessionKey) {
+      revert InvalidSessionKeySignature(recovered, sig.policy.sessionKey);
+    }
+
+    return policyRoot;
+  }
+
+  /// @notice Hashes an x402 session policy into the sapient image hash committed by the wallet config.
+  function hashPolicy(
+    Policy memory policy
+  ) public pure returns (bytes32) {
+    return keccak256(
+      abi.encode(
+        X402_POLICY_TYPEHASH,
+        policy.sessionKey,
+        policy.chainId,
+        policy.token,
+        policy.maxAmountPerPayment,
+        policy.maxPayments,
+        policy.validBefore
+      )
+    );
+  }
+
+  /// @notice Deterministically derives the Permit2 unordered nonce word reserved for a wallet and policy.
+  function permit2NonceWord(
+    address wallet,
+    bytes32 policyRoot
+  ) public view returns (uint256) {
+    return uint256(keccak256(abi.encode(PERMIT2_NONCE_WORD_TYPEHASH, address(this), wallet, policyRoot))) >> 8;
+  }
+
+  /// @notice Hashes a Permit2 witness transfer payment as the external digest checked by ERC-1271.
+  function hashPermit2Payment(
+    Policy memory policy,
+    Permit2Payment memory payment
+  ) public view returns (bytes32) {
+    bytes32 tokenPermissionsHash = keccak256(abi.encode(TOKEN_PERMISSIONS_TYPEHASH, policy.token, payment.amount));
+    bytes32 witness = keccak256(abi.encode(WITNESS_TYPEHASH, payment.witnessTo, payment.witnessValidAfter));
+    bytes32 structHash = keccak256(
+      abi.encode(
+        PERMIT2_WITNESS_TRANSFER_TYPEHASH,
+        tokenPermissionsHash,
+        X402_PERMIT2_PROXY,
+        payment.nonce,
+        payment.deadline,
+        witness
+      )
+    );
+    return keccak256(abi.encodePacked("\x19\x01", _permit2DomainSeparator(), structHash));
+  }
+
+  /// @notice Hashes the session-key authorization over the already reconstructed external payment digest.
+  function hashSessionAuthorization(
+    address wallet,
+    bytes32 policyRoot,
+    bytes32 payloadDigest
+  ) public view returns (bytes32) {
+    bytes32 structHash = keccak256(abi.encode(SESSION_AUTHORIZATION_TYPEHASH, wallet, policyRoot, payloadDigest));
+    return keccak256(abi.encodePacked("\x19\x01", _sessionDomainSeparator(), structHash));
+  }
+
+  function _validatePolicy(
+    Policy memory policy
+  ) internal view {
+    if (policy.sessionKey == address(0)) {
+      revert InvalidSessionKey();
+    }
+    if (policy.token == address(0)) {
+      revert InvalidSessionToken();
+    }
+    if (policy.chainId != 0 && policy.chainId != block.chainid) {
+      revert InvalidChainId(policy.chainId, block.chainid);
+    }
+    if (block.timestamp > policy.validBefore) {
+      revert SessionExpired(policy.validBefore, block.timestamp);
+    }
+    if (policy.maxPayments == 0 || policy.maxPayments > MAX_PERMIT2_NONCE_SLOTS) {
+      revert InvalidMaxPayments(policy.maxPayments, MAX_PERMIT2_NONCE_SLOTS);
+    }
+  }
+
+  function _validateApprovalPayload(
+    Policy memory policy,
+    Payload.Decoded calldata payload
+  ) internal view {
+    if (payload.space > MAX_SPACE) {
+      revert InvalidSpace(payload.space);
+    }
+    if (payload.calls.length != 1) {
+      revert InvalidApprovalCallsLength(payload.calls.length);
+    }
+
+    Payload.Call calldata call = payload.calls[0];
+    if (call.to != policy.token) {
+      revert InvalidToken(call.to, policy.token);
+    }
+    if (
+      call.value != 0 || call.delegateCall || call.onlyFallback
+        || call.behaviorOnError != Payload.BEHAVIOR_REVERT_ON_ERROR
+    ) {
+      revert InvalidApprovalCall();
+    }
+
+    (address spender, uint256 amount) = _decodeApproveCall(call.data);
+    if (spender != PERMIT2) {
+      revert InvalidApprovalSpender(spender, PERMIT2);
+    }
+    if (amount != type(uint256).max) {
+      revert InvalidApprovalAmount(amount, type(uint256).max);
+    }
+  }
+
+  function _payloadHashFor(
+    Payload.Decoded calldata payload,
+    address wallet
+  ) internal view returns (bytes32) {
+    Payload.Decoded memory payloadMemory = payload;
+    return Payload.hashFor(payloadMemory, wallet);
+  }
+
+  function _validatePermit2Payment(
+    Policy memory policy,
+    Permit2Payment memory payment,
+    address wallet,
+    bytes32 policyRoot
+  ) internal view {
+    if (payment.amount == 0 || payment.amount > policy.maxAmountPerPayment) {
+      revert InvalidPaymentAmount(payment.amount, policy.maxAmountPerPayment);
+    }
+
+    uint256 nonceWord = payment.nonce >> 8;
+    uint256 expectedNonceWord = permit2NonceWord(wallet, policyRoot);
+    if (nonceWord != expectedNonceWord) {
+      revert InvalidNonceWord(nonceWord, expectedNonceWord);
+    }
+
+    uint256 nonceSlot = uint8(payment.nonce);
+    if (nonceSlot >= policy.maxPayments) {
+      revert InvalidNonceSlot(nonceSlot, policy.maxPayments);
+    }
+  }
+
+  function _decodeApproveCall(
+    bytes calldata data
+  ) internal pure returns (address spender, uint256 amount) {
+    if (data.length != 68) {
+      revert InvalidApprovalCall();
+    }
+    bytes4 selector = bytes4(data[:4]);
+    if (selector != APPROVE_SELECTOR) {
+      revert InvalidApprovalSelector(selector);
+    }
+    (spender, amount) = abi.decode(data[4:], (address, uint256));
+  }
+
+  function _permit2DomainSeparator() internal view returns (bytes32) {
+    return keccak256(abi.encode(PERMIT2_DOMAIN_TYPEHASH, PERMIT2_NAME_HASH, block.chainid, PERMIT2));
+  }
+
+  function _sessionDomainSeparator() internal view returns (bytes32) {
+    return keccak256(
+      abi.encode(
+        SESSION_DOMAIN_TYPEHASH, SESSION_DOMAIN_NAME_HASH, SESSION_DOMAIN_VERSION_HASH, block.chainid, address(this)
+      )
+    );
+  }
+
+}

--- a/src/extensions/x402/X402SessionSapientSigner.sol
+++ b/src/extensions/x402/X402SessionSapientSigner.sol
@@ -7,19 +7,29 @@ import { Payload } from "../../modules/Payload.sol";
 import { ISapient } from "../../modules/interfaces/ISapient.sol";
 
 /// @title X402SessionSapientSigner
-/// @notice Digest-aware sapient signer for x402 exact Permit2 payments.
+/// @notice Digest-aware sapient signer for x402 exact Permit2 payments with a sliding Permit2 nonce window.
 /// @dev The returned sapient image hash is the policy root committed in the wallet config.
+///      The signer is stateless (`recoverSapientSignature` is `view`): the moving mask comes from `block.timestamp`
+///      and one-time use comes from Permit2's nonce bitmap. The Permit2 nonce is treated as a policy-specific tape:
+///      the Permit2 word starts from a policy-specific hash base, and the linear tape index is an offset from it.
 contract X402SessionSapientSigner is ISapient {
 
   bytes4 public constant APPROVE_SELECTOR = bytes4(keccak256("approve(address,uint256)"));
   uint256 public constant MAX_SPACE = type(uint80).max - 1;
-  uint16 public constant MAX_PERMIT2_NONCE_SLOTS = 256;
+  uint16 public constant MAX_SLIDING_WINDOW_PAYMENTS = type(uint16).max;
+  uint256 public constant PERMIT2_NONCE_BIT_INDEX_BITS = 8;
+  uint256 public constant PERMIT2_BITS_PER_WORD = 256;
+  uint256 public constant NONCE_TAPE_WORD_OFFSET_BITS = 64;
+  uint256 public constant NONCE_TAPE_WORD_BASE_BITS = 184; // Permit2 word bits (248) - word offset bits (64)
+  uint256 public constant NONCE_TAPE_WORD_OFFSET_MASK = uint256(type(uint64).max);
+  uint256 public constant MAX_NONCE_TAPE_INDEX =
+    uint256(type(uint64).max) * PERMIT2_BITS_PER_WORD + (PERMIT2_BITS_PER_WORD - 1);
 
   bytes32 public constant X402_POLICY_TYPEHASH = keccak256(
-    "X402SessionPolicy(address sessionKey,uint256 chainId,address token,uint256 maxAmountPerPayment,uint16 maxPayments,uint256 validBefore)"
+    "X402SessionPolicy(address sessionKey,uint256 chainId,address token,uint256 maxAmountPerPayment,uint64 windowStart,uint64 windowDuration,uint32 maxWindows,uint16 maxPayments,uint256 validBefore)"
   );
-  bytes32 public constant PERMIT2_NONCE_WORD_TYPEHASH =
-    keccak256("SequenceX402Permit2NonceWord(address signer,address wallet,bytes32 policyRoot)");
+  bytes32 public constant PERMIT2_NONCE_WORD_BASE_TYPEHASH =
+    keccak256("SequenceX402Permit2NonceWordBase(address signer,bytes32 policyRoot)");
 
   bytes32 public constant PERMIT2_DOMAIN_TYPEHASH =
     keccak256("EIP712Domain(string name,uint256 chainId,address verifyingContract)");
@@ -45,8 +55,11 @@ contract X402SessionSapientSigner is ISapient {
     uint256 chainId;
     address token;
     uint256 maxAmountPerPayment;
-    uint16 maxPayments;
-    uint256 validBefore;
+    uint64 windowStart; // anchor for tape position 0; also acts as validFrom
+    uint64 windowDuration; // time over which the full maxPayments capacity refills
+    uint32 maxWindows; // hard cap in full refill windows; 0 means unbounded (until validBefore)
+    uint16 maxPayments; // live tape positions in the sliding acceptance mask
+    uint256 validBefore; // hard backstop expiry for the whole policy
   }
 
   struct Permit2Payment {
@@ -81,9 +94,12 @@ contract X402SessionSapientSigner is ISapient {
   error InvalidApprovalAmount(uint256 amount, uint256 expected);
   error InvalidSpace(uint256 space);
   error InvalidPaymentAmount(uint256 amount, uint256 maxAmount);
+  error InvalidWindowDuration();
   error InvalidMaxPayments(uint16 maxPayments, uint16 maxAllowed);
-  error InvalidNonceWord(uint256 word, uint256 expected);
-  error InvalidNonceSlot(uint256 slot, uint16 maxPayments);
+  error WindowNotStarted(uint256 windowStart, uint256 currentTime);
+  error RefillWindowsExhausted(uint256 refillWindowIndex, uint256 maxWindows);
+  error InvalidNonceWord(uint256 word, uint256 minWord, uint256 maxWord);
+  error InvalidNonceTapeIndex(uint256 nonceIndex, uint256 minNonceIndex, uint256 maxNonceIndex);
   error InvalidToken(address token, address expected);
   error InvalidDigest(bytes32 expected, bytes32 actual);
   error InvalidSessionKeySignature(address recovered, address expected);
@@ -122,7 +138,7 @@ contract X402SessionSapientSigner is ISapient {
     bytes32 policyRoot = hashPolicy(sig.policy);
     address wallet = msg.sender;
     _validatePolicy(sig.policy);
-    _validatePermit2Payment(sig.policy, sig.payment, wallet, policyRoot);
+    _validatePermit2Payment(sig.policy, sig.payment, policyRoot);
 
     bytes32 expectedDigest = hashPermit2Payment(sig.policy, sig.payment);
     if (expectedDigest != payload.digest) {
@@ -169,18 +185,94 @@ contract X402SessionSapientSigner is ISapient {
         policy.chainId,
         policy.token,
         policy.maxAmountPerPayment,
+        policy.windowStart,
+        policy.windowDuration,
+        policy.maxWindows,
         policy.maxPayments,
         policy.validBefore
       )
     );
   }
 
-  /// @notice Deterministically derives the Permit2 unordered nonce word reserved for a wallet and policy.
-  function permit2NonceWord(
-    address wallet,
+  /// @notice The full refill-window index at the current block timestamp.
+  /// @dev This is used only for the optional lifetime cap. Payments are authorized by the finer sliding tape range.
+  function currentRefillWindowIndex(
+    Policy memory policy
+  ) public view returns (uint256) {
+    if (block.timestamp < policy.windowStart) {
+      revert WindowNotStarted(policy.windowStart, block.timestamp);
+    }
+    if (policy.windowDuration == 0) {
+      revert InvalidWindowDuration();
+    }
+    return (block.timestamp - policy.windowStart) / policy.windowDuration;
+  }
+
+  /// @notice The inclusive linear Permit2 nonce tape range accepted at the current block timestamp.
+  /// @dev At `windowStart`, the full initial mask `[0, maxPayments - 1]` is live. As time advances, the mask slides
+  ///      by `maxPayments` tape positions per `windowDuration`, with integer rounding toward zero.
+  function currentNonceTapeRange(
+    Policy memory policy
+  ) public view returns (uint256 minNonceIndex, uint256 maxNonceIndex) {
+    if (block.timestamp < policy.windowStart) {
+      revert WindowNotStarted(policy.windowStart, block.timestamp);
+    }
+    if (policy.windowDuration == 0) {
+      revert InvalidWindowDuration();
+    }
+    if (policy.maxPayments == 0) {
+      revert InvalidMaxPayments(policy.maxPayments, MAX_SLIDING_WINDOW_PAYMENTS);
+    }
+
+    uint256 elapsed = block.timestamp - policy.windowStart;
+    minNonceIndex = elapsed * uint256(policy.maxPayments) / uint256(policy.windowDuration);
+    maxNonceIndex = minNonceIndex + uint256(policy.maxPayments) - 1;
+
+    if (policy.maxWindows != 0) {
+      uint256 maxLifetimeNonceIndex = uint256(policy.maxWindows) * uint256(policy.maxPayments) - 1;
+      if (minNonceIndex > maxLifetimeNonceIndex) {
+        revert RefillWindowsExhausted(currentRefillWindowIndex(policy), policy.maxWindows);
+      }
+      if (maxNonceIndex > maxLifetimeNonceIndex) {
+        maxNonceIndex = maxLifetimeNonceIndex;
+      }
+    }
+  }
+
+  /// @notice Deterministically derives the first Permit2 word reserved for a policy's nonce tape.
+  /// @dev The hash prefix is shifted left by 64 bits so the tape can add a 64-bit word offset without wrapping.
+  function permit2NonceWordBase(
     bytes32 policyRoot
   ) public view returns (uint256) {
-    return uint256(keccak256(abi.encode(PERMIT2_NONCE_WORD_TYPEHASH, address(this), wallet, policyRoot))) >> 8;
+    uint256 hashPrefix = uint256(keccak256(abi.encode(PERMIT2_NONCE_WORD_BASE_TYPEHASH, address(this), policyRoot)))
+      >> (256 - NONCE_TAPE_WORD_BASE_BITS);
+    return hashPrefix << NONCE_TAPE_WORD_OFFSET_BITS;
+  }
+
+  /// @notice Returns the Permit2 word for a linear tape index.
+  /// @dev The low 8 bits of `nonceIndex` become the Permit2 bit index. The higher bits become the word offset.
+  function permit2NonceWord(
+    bytes32 policyRoot,
+    uint256 nonceIndex
+  ) public view returns (uint256) {
+    uint256 wordOffset = _nonceIndexToPermit2WordOffset(nonceIndex);
+    return permit2NonceWordBase(policyRoot) + wordOffset;
+  }
+
+  /// @notice Returns the full Permit2 nonce for a linear tape index.
+  function permit2Nonce(
+    bytes32 policyRoot,
+    uint256 nonceIndex
+  ) public view returns (uint256) {
+    return _packPermit2Nonce(permit2NonceWord(policyRoot, nonceIndex), uint8(nonceIndex));
+  }
+
+  /// @notice Decodes a full Permit2 nonce into a linear tape index for the given policy.
+  function decodePermit2Nonce(
+    bytes32 policyRoot,
+    uint256 nonce
+  ) public view returns (uint256 nonceIndex) {
+    return _nonceIndexFromPermit2Nonce(policyRoot, nonce);
   }
 
   /// @notice Hashes a Permit2 witness transfer payment as the external digest checked by ERC-1271.
@@ -228,8 +320,11 @@ contract X402SessionSapientSigner is ISapient {
     if (block.timestamp > policy.validBefore) {
       revert SessionExpired(policy.validBefore, block.timestamp);
     }
-    if (policy.maxPayments == 0 || policy.maxPayments > MAX_PERMIT2_NONCE_SLOTS) {
-      revert InvalidMaxPayments(policy.maxPayments, MAX_PERMIT2_NONCE_SLOTS);
+    if (policy.windowDuration == 0) {
+      revert InvalidWindowDuration();
+    }
+    if (policy.maxPayments == 0) {
+      revert InvalidMaxPayments(policy.maxPayments, MAX_SLIDING_WINDOW_PAYMENTS);
     }
   }
 
@@ -275,23 +370,49 @@ contract X402SessionSapientSigner is ISapient {
   function _validatePermit2Payment(
     Policy memory policy,
     Permit2Payment memory payment,
-    address wallet,
     bytes32 policyRoot
   ) internal view {
     if (payment.amount == 0 || payment.amount > policy.maxAmountPerPayment) {
       revert InvalidPaymentAmount(payment.amount, policy.maxAmountPerPayment);
     }
 
-    uint256 nonceWord = payment.nonce >> 8;
-    uint256 expectedNonceWord = permit2NonceWord(wallet, policyRoot);
-    if (nonceWord != expectedNonceWord) {
-      revert InvalidNonceWord(nonceWord, expectedNonceWord);
+    (uint256 minNonceIndex, uint256 maxNonceIndex) = currentNonceTapeRange(policy);
+
+    uint256 nonceIndex = decodePermit2Nonce(policyRoot, payment.nonce);
+    if (nonceIndex < minNonceIndex || nonceIndex > maxNonceIndex) {
+      revert InvalidNonceTapeIndex(nonceIndex, minNonceIndex, maxNonceIndex);
+    }
+  }
+
+  function _nonceIndexToPermit2WordOffset(
+    uint256 nonceIndex
+  ) internal pure returns (uint256 wordOffset) {
+    wordOffset = nonceIndex >> PERMIT2_NONCE_BIT_INDEX_BITS;
+    if (wordOffset > NONCE_TAPE_WORD_OFFSET_MASK) {
+      revert InvalidNonceTapeIndex(nonceIndex, 0, MAX_NONCE_TAPE_INDEX);
+    }
+  }
+
+  function _nonceIndexFromPermit2Nonce(
+    bytes32 policyRoot,
+    uint256 nonce
+  ) internal view returns (uint256) {
+    uint256 word = nonce >> PERMIT2_NONCE_BIT_INDEX_BITS;
+    uint256 minWord = permit2NonceWordBase(policyRoot);
+    uint256 maxWord = minWord + NONCE_TAPE_WORD_OFFSET_MASK;
+    if (word < minWord || word > maxWord) {
+      revert InvalidNonceWord(word, minWord, maxWord);
     }
 
-    uint256 nonceSlot = uint8(payment.nonce);
-    if (nonceSlot >= policy.maxPayments) {
-      revert InvalidNonceSlot(nonceSlot, policy.maxPayments);
-    }
+    uint256 wordOffset = word - minWord;
+    return wordOffset * PERMIT2_BITS_PER_WORD + uint8(nonce);
+  }
+
+  function _packPermit2Nonce(
+    uint256 word,
+    uint8 bitIndex
+  ) internal pure returns (uint256) {
+    return (word << PERMIT2_NONCE_BIT_INDEX_BITS) | bitIndex;
   }
 
   function _decodeApproveCall(

--- a/test/extensions/x402/X402SessionSapientSigner.t.sol
+++ b/test/extensions/x402/X402SessionSapientSigner.t.sol
@@ -46,6 +46,10 @@ contract X402SessionSapientSignerTest is Test {
   address internal constant PAY_TO = address(0x209693Bc6afc0C5328bA36FaF03C514EF312287C);
   bytes4 internal constant APPROVE_SELECTOR = bytes4(keccak256("approve(address,uint256)"));
 
+  uint64 internal constant WINDOW_START = 1000;
+  uint64 internal constant WINDOW_DURATION = 30 days;
+  uint32 internal constant MAX_WINDOWS = 12;
+
   bytes32 internal constant CANONICAL_TOKEN_PERMISSIONS_TYPEHASH =
     keccak256("TokenPermissions(address token,uint256 amount)");
   bytes32 internal constant CANONICAL_WITNESS_TYPEHASH = keccak256("Witness(address to,uint256 validAfter)");
@@ -60,7 +64,7 @@ contract X402SessionSapientSignerTest is Test {
     signer = new X402SessionSapientSigner(PERMIT2, X402_PERMIT2_PROXY);
     wallet = new X402AuthHarness();
     sessionKey = vm.createWallet("x402-session-key");
-    vm.warp(1000);
+    vm.warp(WINDOW_START); // start at the beginning of window 0
   }
 
   function test_recoverSapientSignature_acceptsValidPermit2Payment() external {
@@ -87,6 +91,168 @@ contract X402SessionSapientSignerTest is Test {
 
     assertEq(signer.hashPermit2Payment(policy, payment), _canonicalX402ProxyDigest(policy, payment));
   }
+
+  // --- sliding, auto-renewing Permit2 nonce tape ---------------------------------------------------------------
+
+  function test_recoverSapientSignature_slidesAcceptedNonceRangeWithoutReconfiguring() external {
+    X402SessionSapientSigner.Policy memory policy = _validPolicy();
+    bytes32 policyRoot = signer.hashPolicy(policy);
+
+    (uint256 min0, uint256 max0) = signer.currentNonceTapeRange(policy);
+    assertEq(min0, 0);
+    assertEq(max0, policy.maxPayments - 1);
+
+    // At the policy start, the full initial mask is live.
+    (Payload.Decoded memory p0, bytes memory s0,) = _payloadAndSignature(policy, _paymentAtIndex(policy, 0));
+    vm.prank(address(wallet));
+    assertEq(signer.recoverSapientSignature(p0, s0), policyRoot, "oldest live position should be accepted");
+
+    (Payload.Decoded memory p4, bytes memory s4,) = _payloadAndSignature(policy, _paymentAtIndex(policy, 4));
+    vm.prank(address(wallet));
+    assertEq(signer.recoverSapientSignature(p4, s4), policyRoot, "newest live position should be accepted");
+
+    // The first not-yet-live tape position is rejected.
+    (Payload.Decoded memory p5, bytes memory s5,) = _payloadAndSignature(policy, _paymentAtIndex(policy, 5));
+    vm.expectRevert(
+      abi.encodeWithSelector(
+        X402SessionSapientSigner.InvalidNonceTapeIndex.selector, uint256(5), uint256(0), uint256(4)
+      )
+    );
+    vm.prank(address(wallet));
+    signer.recoverSapientSignature(p5, s5);
+
+    // Advance by one refill quantum. The accepted mask moves from [0..4] to [1..5].
+    vm.warp(WINDOW_START + WINDOW_DURATION / policy.maxPayments);
+    (uint256 min1, uint256 max1) = signer.currentNonceTapeRange(policy);
+    assertEq(min1, 1);
+    assertEq(max1, 5);
+
+    vm.prank(address(wallet));
+    assertEq(signer.recoverSapientSignature(p5, s5), policyRoot, "new tape position should now be accepted");
+
+    // The oldest position fell out of the mask.
+    vm.expectRevert(
+      abi.encodeWithSelector(
+        X402SessionSapientSigner.InvalidNonceTapeIndex.selector, uint256(0), uint256(1), uint256(5)
+      )
+    );
+    vm.prank(address(wallet));
+    signer.recoverSapientSignature(p0, s0);
+  }
+
+  function test_permit2Nonce_sameBitDifferentTapeWordsYieldDistinctNonces() external view {
+    bytes32 policyRoot = signer.hashPolicy(_validPolicy());
+    uint256 firstNonce = signer.permit2Nonce(policyRoot, 2);
+    uint256 secondNonce = signer.permit2Nonce(policyRoot, 258);
+
+    assertEq(uint8(firstNonce), uint8(2));
+    assertEq(uint8(secondNonce), uint8(2));
+    assertTrue(firstNonce != secondNonce);
+
+    uint256 wordBase = signer.permit2NonceWordBase(policyRoot);
+    assertEq(firstNonce >> signer.PERMIT2_NONCE_BIT_INDEX_BITS(), wordBase);
+    assertEq(secondNonce >> signer.PERMIT2_NONCE_BIT_INDEX_BITS(), wordBase + 1);
+    assertEq(signer.decodePermit2Nonce(policyRoot, firstNonce), 2);
+    assertEq(signer.decodePermit2Nonce(policyRoot, secondNonce), 258);
+  }
+
+  function test_recoverSapientSignature_rejectsPaymentBeforeWindowStart() external {
+    X402SessionSapientSigner.Policy memory policy = _validPolicy();
+    (Payload.Decoded memory payload, bytes memory encoded,) = _payloadAndSignature(policy, _paymentAtIndex(policy, 0));
+
+    vm.warp(WINDOW_START - 1);
+    vm.expectRevert(
+      abi.encodeWithSelector(X402SessionSapientSigner.WindowNotStarted.selector, WINDOW_START, WINDOW_START - 1)
+    );
+    vm.prank(address(wallet));
+    signer.recoverSapientSignature(payload, encoded);
+  }
+
+  function test_recoverSapientSignature_rejectsOnceWindowsAreExhausted() external {
+    X402SessionSapientSigner.Policy memory policy = _validPolicy();
+    uint256 firstExpiredIndex = uint256(policy.maxWindows) * uint256(policy.maxPayments);
+    (Payload.Decoded memory payload, bytes memory encoded,) =
+      _payloadAndSignature(policy, _paymentAtIndex(policy, firstExpiredIndex));
+
+    // Jump to the first full refill window after the lifetime cap.
+    vm.warp(WINDOW_START + uint256(WINDOW_DURATION) * MAX_WINDOWS);
+    vm.expectRevert(
+      abi.encodeWithSelector(X402SessionSapientSigner.RefillWindowsExhausted.selector, MAX_WINDOWS, MAX_WINDOWS)
+    );
+    vm.prank(address(wallet));
+    signer.recoverSapientSignature(payload, encoded);
+  }
+
+  function test_recoverSapientSignature_acceptsPaymentInLastAllowedWindow() external {
+    X402SessionSapientSigner.Policy memory policy = _validPolicy();
+    bytes32 policyRoot = signer.hashPolicy(policy);
+    uint256 lastWindow = MAX_WINDOWS - 1;
+    uint256 lastAllowedIndex = uint256(policy.maxWindows) * uint256(policy.maxPayments) - 1;
+    (Payload.Decoded memory payload, bytes memory encoded,) =
+      _payloadAndSignature(policy, _paymentAtIndex(policy, lastAllowedIndex));
+
+    vm.warp(WINDOW_START + uint256(WINDOW_DURATION) * lastWindow);
+    vm.prank(address(wallet));
+    assertEq(signer.recoverSapientSignature(payload, encoded), policyRoot);
+  }
+
+  function test_recoverSapientSignature_allowsMultiplePaymentsWithinSlidingMaskUpToCap() external {
+    X402SessionSapientSigner.Policy memory policy = _validPolicy();
+    policy.maxPayments = 3;
+    bytes32 policyRoot = signer.hashPolicy(policy);
+
+    for (uint256 nonceIndex = 0; nonceIndex < 3; nonceIndex++) {
+      (Payload.Decoded memory payload, bytes memory encoded,) =
+        _payloadAndSignature(policy, _paymentAtIndex(policy, nonceIndex));
+      vm.prank(address(wallet));
+      assertEq(signer.recoverSapientSignature(payload, encoded), policyRoot, "index within mask should be accepted");
+    }
+
+    (Payload.Decoded memory overPayload, bytes memory overEncoded,) =
+      _payloadAndSignature(policy, _paymentAtIndex(policy, 3));
+    vm.expectRevert(
+      abi.encodeWithSelector(
+        X402SessionSapientSigner.InvalidNonceTapeIndex.selector, uint256(3), uint256(0), uint256(2)
+      )
+    );
+    vm.prank(address(wallet));
+    signer.recoverSapientSignature(overPayload, overEncoded);
+  }
+
+  function test_recoverSapientSignature_slidingMaskCanSpanPermit2Words() external {
+    X402SessionSapientSigner.Policy memory policy = _validPolicy();
+    policy.maxPayments = 300;
+    bytes32 policyRoot = signer.hashPolicy(policy);
+
+    (Payload.Decoded memory payload, bytes memory encoded,) = _payloadAndSignature(policy, _paymentAtIndex(policy, 299));
+
+    vm.prank(address(wallet));
+    assertEq(signer.recoverSapientSignature(payload, encoded), policyRoot);
+
+    (Payload.Decoded memory overPayload, bytes memory overEncoded,) =
+      _payloadAndSignature(policy, _paymentAtIndex(policy, 300));
+    vm.expectRevert(
+      abi.encodeWithSelector(
+        X402SessionSapientSigner.InvalidNonceTapeIndex.selector, uint256(300), uint256(0), uint256(299)
+      )
+    );
+    vm.prank(address(wallet));
+    signer.recoverSapientSignature(overPayload, overEncoded);
+  }
+
+  function test_recoverSapientSignature_allowsVariableAmountUnderCap() external {
+    // "utility bill" case: a different (smaller) amount is fine, as long as it is <= the cap.
+    X402SessionSapientSigner.Policy memory policy = _validPolicy();
+    bytes32 policyRoot = signer.hashPolicy(policy);
+    X402SessionSapientSigner.Permit2Payment memory payment = _paymentAtIndex(policy, 0);
+    payment.amount = policy.maxAmountPerPayment / 3;
+    (Payload.Decoded memory payload, bytes memory encoded,) = _payloadAndSignature(policy, payment);
+
+    vm.prank(address(wallet));
+    assertEq(signer.recoverSapientSignature(payload, encoded), policyRoot);
+  }
+
+  // --- approval setup path -------------------------------------------------------------------------------------
 
   function test_recoverSapientSignature_acceptsPermit2ApprovalTransaction() external {
     X402SessionSapientSigner.Policy memory policy = _validPolicy();
@@ -227,6 +393,8 @@ contract X402SessionSapientSignerTest is Test {
     assertEq(token.allowance(address(wallet), PERMIT2), 0);
   }
 
+  // --- structural validation -----------------------------------------------------------------------------------
+
   function test_constructor_rejectsZeroPermit2() external {
     vm.expectRevert(X402SessionSapientSigner.InvalidPermit2.selector);
     new X402SessionSapientSigner(address(0), X402_PERMIT2_PROXY);
@@ -280,6 +448,17 @@ contract X402SessionSapientSignerTest is Test {
     signer.recoverSapientSignature(payload, encoded);
   }
 
+  function test_recoverSapientSignature_rejectsZeroWindowDuration() external {
+    X402SessionSapientSigner.Policy memory policy = _validPolicy();
+    policy.windowDuration = 0;
+    X402SessionSapientSigner.Permit2Payment memory payment = _validPayment(policy);
+    (Payload.Decoded memory payload, bytes memory encoded,) = _payloadAndSignature(policy, payment);
+
+    vm.expectRevert(X402SessionSapientSigner.InvalidWindowDuration.selector);
+    vm.prank(address(wallet));
+    signer.recoverSapientSignature(payload, encoded);
+  }
+
   function test_recoverSapientSignature_rejectsZeroMaxPayments() external {
     X402SessionSapientSigner.Policy memory policy = _validPolicy();
     policy.maxPayments = 0;
@@ -288,35 +467,18 @@ contract X402SessionSapientSignerTest is Test {
 
     vm.expectRevert(
       abi.encodeWithSelector(
-        X402SessionSapientSigner.InvalidMaxPayments.selector, uint16(0), signer.MAX_PERMIT2_NONCE_SLOTS()
+        X402SessionSapientSigner.InvalidMaxPayments.selector, uint16(0), signer.MAX_SLIDING_WINDOW_PAYMENTS()
       )
     );
     vm.prank(address(wallet));
     signer.recoverSapientSignature(payload, encoded);
   }
 
-  function test_recoverSapientSignature_rejectsMaxPaymentsAboveLimit() external {
+  function test_recoverSapientSignature_acceptsMaxPaymentsBoundaryIndex() external {
     X402SessionSapientSigner.Policy memory policy = _validPolicy();
-    policy.maxPayments = signer.MAX_PERMIT2_NONCE_SLOTS() + 1;
-    X402SessionSapientSigner.Permit2Payment memory payment = _validPayment(policy);
-    (Payload.Decoded memory payload, bytes memory encoded,) = _payloadAndSignature(policy, payment);
-
-    vm.expectRevert(
-      abi.encodeWithSelector(
-        X402SessionSapientSigner.InvalidMaxPayments.selector, policy.maxPayments, signer.MAX_PERMIT2_NONCE_SLOTS()
-      )
-    );
-    vm.prank(address(wallet));
-    signer.recoverSapientSignature(payload, encoded);
-  }
-
-  function test_recoverSapientSignature_acceptsMaxPaymentsBoundarySlot() external {
-    X402SessionSapientSigner.Policy memory policy = _validPolicy();
-    policy.maxPayments = signer.MAX_PERMIT2_NONCE_SLOTS();
+    policy.maxPayments = signer.MAX_SLIDING_WINDOW_PAYMENTS();
     bytes32 policyRoot = signer.hashPolicy(policy);
-    uint256 nonceWord = signer.permit2NonceWord(address(wallet), policyRoot);
-    X402SessionSapientSigner.Permit2Payment memory payment = _validPayment(policy);
-    payment.nonce = (nonceWord << 8) | 255;
+    X402SessionSapientSigner.Permit2Payment memory payment = _paymentAtIndex(policy, policy.maxPayments - 1);
     (Payload.Decoded memory payload, bytes memory encoded,) = _payloadAndSignature(policy, payment);
 
     vm.prank(address(wallet));
@@ -434,32 +596,32 @@ contract X402SessionSapientSignerTest is Test {
     signer.recoverSapientSignature(payload, encoded);
   }
 
-  function test_recoverSapientSignature_rejectsNonceOutsideSessionWord() external {
+  function test_recoverSapientSignature_rejectsNonceOutsidePolicyWordBase() external {
     X402SessionSapientSigner.Policy memory policy = _validPolicy();
     bytes32 policyRoot = signer.hashPolicy(policy);
-    uint256 nonceWord = signer.permit2NonceWord(address(wallet), policyRoot);
-    X402SessionSapientSigner.Permit2Payment memory payment = _validPayment(policy);
-    payment.nonce = ((nonceWord + 1) << 8) | 1;
+    X402SessionSapientSigner.Permit2Payment memory payment = _paymentAtIndex(policy, 1);
+    payment.nonce ^= uint256(1) << (signer.PERMIT2_NONCE_BIT_INDEX_BITS() + signer.NONCE_TAPE_WORD_OFFSET_BITS());
     (Payload.Decoded memory payload, bytes memory encoded,) = _payloadAndSignature(policy, payment);
 
-    vm.expectRevert(
-      abi.encodeWithSelector(X402SessionSapientSigner.InvalidNonceWord.selector, nonceWord + 1, nonceWord)
-    );
+    uint256 word = payment.nonce >> signer.PERMIT2_NONCE_BIT_INDEX_BITS();
+    uint256 minWord = signer.permit2NonceWordBase(policyRoot);
+    uint256 maxWord = minWord + signer.NONCE_TAPE_WORD_OFFSET_MASK();
+    vm.expectRevert(abi.encodeWithSelector(X402SessionSapientSigner.InvalidNonceWord.selector, word, minWord, maxWord));
     vm.prank(address(wallet));
     signer.recoverSapientSignature(payload, encoded);
   }
 
-  function test_recoverSapientSignature_rejectsNonceSlotAbovePaymentLimit() external {
+  function test_recoverSapientSignature_rejectsNonceIndexOutsideSlidingMask() external {
     X402SessionSapientSigner.Policy memory policy = _validPolicy();
-    bytes32 policyRoot = signer.hashPolicy(policy);
-    uint256 nonceWord = signer.permit2NonceWord(address(wallet), policyRoot);
-    X402SessionSapientSigner.Permit2Payment memory payment = _validPayment(policy);
-    payment.nonce = (nonceWord << 8) | policy.maxPayments;
+    X402SessionSapientSigner.Permit2Payment memory payment = _paymentAtIndex(policy, policy.maxPayments);
     (Payload.Decoded memory payload, bytes memory encoded,) = _payloadAndSignature(policy, payment);
 
     vm.expectRevert(
       abi.encodeWithSelector(
-        X402SessionSapientSigner.InvalidNonceSlot.selector, uint256(policy.maxPayments), policy.maxPayments
+        X402SessionSapientSigner.InvalidNonceTapeIndex.selector,
+        uint256(policy.maxPayments),
+        uint256(0),
+        uint256(policy.maxPayments) - 1
       )
     );
     vm.prank(address(wallet));
@@ -551,6 +713,8 @@ contract X402SessionSapientSignerTest is Test {
     vm.prank(address(wallet));
     signer.recoverSapientSignature(payload, encoded);
   }
+
+  // --- helpers -------------------------------------------------------------------------------------------------
 
   function _validPayloadAndSignature()
     internal
@@ -649,19 +813,29 @@ contract X402SessionSapientSignerTest is Test {
     policy.chainId = block.chainid;
     policy.token = TOKEN;
     policy.maxAmountPerPayment = 1e6;
+    policy.windowStart = WINDOW_START;
+    policy.windowDuration = WINDOW_DURATION;
+    policy.maxWindows = MAX_WINDOWS;
     policy.maxPayments = 5;
-    policy.validBefore = 2000;
+    // Backstop expiry comfortably beyond the lifetime cap so exhaustion tests do not hit SessionExpired first.
+    policy.validBefore = uint256(WINDOW_START) + uint256(WINDOW_DURATION) * (uint256(MAX_WINDOWS) + 2);
   }
 
   function _validPayment(
     X402SessionSapientSigner.Policy memory policy
   ) internal view returns (X402SessionSapientSigner.Permit2Payment memory payment) {
-    uint256 nonceWord = signer.permit2NonceWord(address(wallet), signer.hashPolicy(policy));
-    payment.amount = 1e6;
-    payment.nonce = (nonceWord << 8) | 2;
-    payment.deadline = 1800;
+    return _paymentAtIndex(policy, 2);
+  }
+
+  function _paymentAtIndex(
+    X402SessionSapientSigner.Policy memory policy,
+    uint256 nonceIndex
+  ) internal view returns (X402SessionSapientSigner.Permit2Payment memory payment) {
+    payment.amount = policy.maxAmountPerPayment;
+    payment.nonce = signer.permit2Nonce(signer.hashPolicy(policy), nonceIndex);
+    payment.deadline = uint256(policy.windowStart) + uint256(policy.windowDuration);
     payment.witnessTo = PAY_TO;
-    payment.witnessValidAfter = 1000;
+    payment.witnessValidAfter = uint256(policy.windowStart);
   }
 
   function _canonicalX402ProxyDigest(

--- a/test/extensions/x402/X402SessionSapientSigner.t.sol
+++ b/test/extensions/x402/X402SessionSapientSigner.t.sol
@@ -1,0 +1,767 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.27;
+
+import { Test, Vm } from "forge-std/Test.sol";
+
+import { MockERC20 } from "test/mocks/MockERC20.sol";
+
+import { X402SessionSapientSigner } from "src/extensions/x402/X402SessionSapientSigner.sol";
+import { Calls } from "src/modules/Calls.sol";
+import { Payload } from "src/modules/Payload.sol";
+import { IERC1271_MAGIC_VALUE_HASH } from "src/modules/interfaces/IERC1271.sol";
+
+contract X402AuthHarness is Calls {
+
+  bytes32 public imageHash;
+
+  function setImageHash(
+    bytes32 newImageHash
+  ) external {
+    imageHash = newImageHash;
+  }
+
+  function _isValidImage(
+    bytes32 candidate
+  ) internal view override returns (bool) {
+    return candidate != bytes32(0) && candidate == imageHash;
+  }
+
+  function _updateImageHash(
+    bytes32 newImageHash
+  ) internal override {
+    imageHash = newImageHash;
+  }
+
+}
+
+contract X402SessionSapientSignerTest is Test {
+
+  X402SessionSapientSigner internal signer;
+  X402AuthHarness internal wallet;
+  Vm.Wallet internal sessionKey;
+
+  address internal constant PERMIT2 = address(0x000000000022D473030F116dDEE9F6B43aC78BA3);
+  address internal constant X402_PERMIT2_PROXY = address(0x402085c248EeA27D92E8b30b2C58ed07f9E20001);
+  address internal constant TOKEN = address(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48);
+  address internal constant PAY_TO = address(0x209693Bc6afc0C5328bA36FaF03C514EF312287C);
+  bytes4 internal constant APPROVE_SELECTOR = bytes4(keccak256("approve(address,uint256)"));
+
+  bytes32 internal constant CANONICAL_TOKEN_PERMISSIONS_TYPEHASH =
+    keccak256("TokenPermissions(address token,uint256 amount)");
+  bytes32 internal constant CANONICAL_WITNESS_TYPEHASH = keccak256("Witness(address to,uint256 validAfter)");
+  bytes32 internal constant CANONICAL_PERMIT2_WITNESS_TRANSFER_TYPEHASH = keccak256(
+    "PermitWitnessTransferFrom(TokenPermissions permitted,address spender,uint256 nonce,uint256 deadline,Witness witness)TokenPermissions(address token,uint256 amount)Witness(address to,uint256 validAfter)"
+  );
+  bytes32 internal constant CANONICAL_PERMIT2_DOMAIN_TYPEHASH =
+    keccak256("EIP712Domain(string name,uint256 chainId,address verifyingContract)");
+  bytes32 internal constant CANONICAL_PERMIT2_NAME_HASH = keccak256("Permit2");
+
+  function setUp() external {
+    signer = new X402SessionSapientSigner(PERMIT2, X402_PERMIT2_PROXY);
+    wallet = new X402AuthHarness();
+    sessionKey = vm.createWallet("x402-session-key");
+    vm.warp(1000);
+  }
+
+  function test_recoverSapientSignature_acceptsValidPermit2Payment() external {
+    (Payload.Decoded memory payload, bytes memory encoded, bytes32 policyRoot) = _validPayloadAndSignature();
+
+    vm.prank(address(wallet));
+    bytes32 recovered = signer.recoverSapientSignature(payload, encoded);
+
+    assertEq(recovered, policyRoot);
+  }
+
+  function test_isValidSignature_acceptsValidPermit2PaymentThroughBaseAuth() external {
+    (Payload.Decoded memory payload, bytes memory encoded, bytes32 policyRoot) = _validPayloadAndSignature();
+    wallet.setImageHash(_sequenceImageHash(address(signer), 1, policyRoot));
+
+    bytes memory sequenceSignature = _encodeSequenceSapientSignature(address(signer), 1, encoded);
+
+    assertEq(wallet.isValidSignature(payload.digest, sequenceSignature), IERC1271_MAGIC_VALUE_HASH);
+  }
+
+  function test_hashPermit2Payment_matchesCanonicalX402ProxyDigest() external view {
+    X402SessionSapientSigner.Policy memory policy = _validPolicy();
+    X402SessionSapientSigner.Permit2Payment memory payment = _validPayment(policy);
+
+    assertEq(signer.hashPermit2Payment(policy, payment), _canonicalX402ProxyDigest(policy, payment));
+  }
+
+  function test_recoverSapientSignature_acceptsPermit2ApprovalTransaction() external {
+    X402SessionSapientSigner.Policy memory policy = _validPolicy();
+    (Payload.Decoded memory payload, bytes memory encoded, bytes32 policyRoot) =
+      _approvalPayloadAndSignature(policy, TOKEN, PERMIT2, type(uint256).max);
+
+    vm.prank(address(wallet));
+    bytes32 recovered = signer.recoverSapientSignature(payload, encoded);
+
+    assertEq(recovered, policyRoot);
+  }
+
+  function test_recoverSapientSignature_acceptsPermit2ApprovalForPolicyToken() external {
+    X402SessionSapientSigner.Policy memory policy = _validPolicy();
+    policy.token = address(0xBEEF);
+    (Payload.Decoded memory payload, bytes memory encoded, bytes32 policyRoot) =
+      _approvalPayloadAndSignature(policy, policy.token, PERMIT2, type(uint256).max);
+
+    vm.prank(address(wallet));
+    bytes32 recovered = signer.recoverSapientSignature(payload, encoded);
+
+    assertEq(recovered, policyRoot);
+  }
+
+  function test_recoverSapientSignature_rejectsApprovalForTokenOutsidePolicy() external {
+    X402SessionSapientSigner.Policy memory policy = _validPolicy();
+    (Payload.Decoded memory payload, bytes memory encoded,) =
+      _approvalPayloadAndSignature(policy, address(0xBEEF), PERMIT2, type(uint256).max);
+
+    vm.expectRevert(abi.encodeWithSelector(X402SessionSapientSigner.InvalidToken.selector, address(0xBEEF), TOKEN));
+    vm.prank(address(wallet));
+    signer.recoverSapientSignature(payload, encoded);
+  }
+
+  function test_recoverSapientSignature_rejectsApprovalWrongSpender() external {
+    X402SessionSapientSigner.Policy memory policy = _validPolicy();
+    (Payload.Decoded memory payload, bytes memory encoded,) =
+      _approvalPayloadAndSignature(policy, TOKEN, address(0xBEEF), type(uint256).max);
+
+    vm.expectRevert(
+      abi.encodeWithSelector(X402SessionSapientSigner.InvalidApprovalSpender.selector, address(0xBEEF), PERMIT2)
+    );
+    vm.prank(address(wallet));
+    signer.recoverSapientSignature(payload, encoded);
+  }
+
+  function test_recoverSapientSignature_rejectsApprovalAmountBelowMax() external {
+    X402SessionSapientSigner.Policy memory policy = _validPolicy();
+    (Payload.Decoded memory payload, bytes memory encoded,) = _approvalPayloadAndSignature(policy, TOKEN, PERMIT2, 1);
+
+    vm.expectRevert(
+      abi.encodeWithSelector(X402SessionSapientSigner.InvalidApprovalAmount.selector, 1, type(uint256).max)
+    );
+    vm.prank(address(wallet));
+    signer.recoverSapientSignature(payload, encoded);
+  }
+
+  function test_recoverSapientSignature_rejectsApprovalRevocation() external {
+    X402SessionSapientSigner.Policy memory policy = _validPolicy();
+    (Payload.Decoded memory payload, bytes memory encoded,) = _approvalPayloadAndSignature(policy, TOKEN, PERMIT2, 0);
+
+    vm.expectRevert(
+      abi.encodeWithSelector(X402SessionSapientSigner.InvalidApprovalAmount.selector, 0, type(uint256).max)
+    );
+    vm.prank(address(wallet));
+    signer.recoverSapientSignature(payload, encoded);
+  }
+
+  function test_recoverSapientSignature_rejectsApprovalOutsideSessionNonceSpace() external {
+    X402SessionSapientSigner.Policy memory policy = _validPolicy();
+    Payload.Decoded memory payload = _approvalPayload(TOKEN, PERMIT2, type(uint256).max);
+    payload.space = signer.MAX_SPACE() + 1;
+    bytes memory encoded = _approvalSignature(policy, payload);
+
+    vm.expectRevert(abi.encodeWithSelector(X402SessionSapientSigner.InvalidSpace.selector, payload.space));
+    vm.prank(address(wallet));
+    signer.recoverSapientSignature(payload, encoded);
+  }
+
+  function test_recoverSapientSignature_rejectsInvalidApprovalSessionSignature() external {
+    X402SessionSapientSigner.Policy memory policy = _validPolicy();
+    Payload.Decoded memory payload = _approvalPayload(TOKEN, PERMIT2, type(uint256).max);
+    bytes32 policyRoot = signer.hashPolicy(policy);
+    bytes32 payloadDigest = Payload.hashFor(payload, address(wallet));
+    bytes32 authDigest = signer.hashSessionAuthorization(address(wallet), policyRoot, payloadDigest);
+
+    Vm.Wallet memory wrongKey = vm.createWallet("wrong-approval-key");
+    bytes memory badSignature = _sign(wrongKey.privateKey, authDigest);
+    bytes memory encoded = _encodeApproval(policy, badSignature);
+    address recovered = _recover(authDigest, badSignature);
+
+    vm.expectRevert(
+      abi.encodeWithSelector(X402SessionSapientSigner.InvalidSessionKeySignature.selector, recovered, policy.sessionKey)
+    );
+    vm.prank(address(wallet));
+    signer.recoverSapientSignature(payload, encoded);
+  }
+
+  function test_execute_runsPermit2ApprovalEndToEnd() external {
+    MockERC20 token = new MockERC20();
+    X402SessionSapientSigner.Policy memory policy = _validPolicy();
+    policy.token = address(token);
+
+    Payload.Decoded memory payload = _approvalPayload(address(token), PERMIT2, type(uint256).max);
+    bytes memory approvalSignature = _approvalSignature(policy, payload);
+    bytes32 policyRoot = signer.hashPolicy(policy);
+    wallet.setImageHash(_sequenceImageHash(address(signer), 1, policyRoot));
+
+    bytes memory packed = _packApproval(address(token), PERMIT2, type(uint256).max);
+    bytes memory sequenceSignature = _encodeSequenceSapientSignature(address(signer), 1, approvalSignature);
+
+    assertEq(token.allowance(address(wallet), PERMIT2), 0);
+
+    wallet.execute(packed, sequenceSignature);
+
+    assertEq(token.allowance(address(wallet), PERMIT2), type(uint256).max);
+  }
+
+  function test_execute_rejectsTamperedApprovalPayload() external {
+    MockERC20 token = new MockERC20();
+    X402SessionSapientSigner.Policy memory policy = _validPolicy();
+    policy.token = address(token);
+
+    // The session key signs an approval in nonce space 0...
+    Payload.Decoded memory payload = _approvalPayload(address(token), PERMIT2, type(uint256).max);
+    bytes memory approvalSignature = _approvalSignature(policy, payload);
+    wallet.setImageHash(_sequenceImageHash(address(signer), 1, signer.hashPolicy(policy)));
+    bytes memory sequenceSignature = _encodeSequenceSapientSignature(address(signer), 1, approvalSignature);
+
+    // ...but the submitted transaction is executed in a different nonce space.
+    // The space is still in policy and passes structural checks, yet the op hash
+    // changes, so the session-key signature no longer recovers, and execute reverts.
+    bytes memory packed = _packApprovalInSpace(address(token), PERMIT2, type(uint256).max, 7);
+
+    vm.expectRevert();
+    wallet.execute(packed, sequenceSignature);
+
+    assertEq(token.allowance(address(wallet), PERMIT2), 0);
+  }
+
+  function test_constructor_rejectsZeroPermit2() external {
+    vm.expectRevert(X402SessionSapientSigner.InvalidPermit2.selector);
+    new X402SessionSapientSigner(address(0), X402_PERMIT2_PROXY);
+  }
+
+  function test_constructor_rejectsZeroProxy() external {
+    vm.expectRevert(X402SessionSapientSigner.InvalidPermit2.selector);
+    new X402SessionSapientSigner(PERMIT2, address(0));
+  }
+
+  function test_recoverSapientSignature_rejectsUnsupportedPayloadKind() external {
+    Payload.Decoded memory payload = Payload.fromMessage(bytes("x402"));
+
+    vm.expectRevert(abi.encodeWithSelector(X402SessionSapientSigner.InvalidPayloadKind.selector, Payload.KIND_MESSAGE));
+    vm.prank(address(wallet));
+    signer.recoverSapientSignature(payload, "");
+  }
+
+  function test_recoverSapientSignature_rejectsZeroSessionKey() external {
+    X402SessionSapientSigner.Policy memory policy = _validPolicy();
+    policy.sessionKey = address(0);
+    X402SessionSapientSigner.Permit2Payment memory payment = _validPayment(policy);
+    (Payload.Decoded memory payload, bytes memory encoded,) = _payloadAndSignature(policy, payment);
+
+    vm.expectRevert(X402SessionSapientSigner.InvalidSessionKey.selector);
+    vm.prank(address(wallet));
+    signer.recoverSapientSignature(payload, encoded);
+  }
+
+  function test_recoverSapientSignature_rejectsZeroToken() external {
+    X402SessionSapientSigner.Policy memory policy = _validPolicy();
+    policy.token = address(0);
+    X402SessionSapientSigner.Permit2Payment memory payment = _validPayment(policy);
+    (Payload.Decoded memory payload, bytes memory encoded,) = _payloadAndSignature(policy, payment);
+
+    vm.expectRevert(X402SessionSapientSigner.InvalidSessionToken.selector);
+    vm.prank(address(wallet));
+    signer.recoverSapientSignature(payload, encoded);
+  }
+
+  function test_recoverSapientSignature_rejectsExpiredSession() external {
+    X402SessionSapientSigner.Policy memory policy = _validPolicy();
+    policy.validBefore = block.timestamp - 1;
+    X402SessionSapientSigner.Permit2Payment memory payment = _validPayment(policy);
+    (Payload.Decoded memory payload, bytes memory encoded,) = _payloadAndSignature(policy, payment);
+
+    vm.expectRevert(
+      abi.encodeWithSelector(X402SessionSapientSigner.SessionExpired.selector, policy.validBefore, block.timestamp)
+    );
+    vm.prank(address(wallet));
+    signer.recoverSapientSignature(payload, encoded);
+  }
+
+  function test_recoverSapientSignature_rejectsZeroMaxPayments() external {
+    X402SessionSapientSigner.Policy memory policy = _validPolicy();
+    policy.maxPayments = 0;
+    X402SessionSapientSigner.Permit2Payment memory payment = _validPayment(policy);
+    (Payload.Decoded memory payload, bytes memory encoded,) = _payloadAndSignature(policy, payment);
+
+    vm.expectRevert(
+      abi.encodeWithSelector(
+        X402SessionSapientSigner.InvalidMaxPayments.selector, uint16(0), signer.MAX_PERMIT2_NONCE_SLOTS()
+      )
+    );
+    vm.prank(address(wallet));
+    signer.recoverSapientSignature(payload, encoded);
+  }
+
+  function test_recoverSapientSignature_rejectsMaxPaymentsAboveLimit() external {
+    X402SessionSapientSigner.Policy memory policy = _validPolicy();
+    policy.maxPayments = signer.MAX_PERMIT2_NONCE_SLOTS() + 1;
+    X402SessionSapientSigner.Permit2Payment memory payment = _validPayment(policy);
+    (Payload.Decoded memory payload, bytes memory encoded,) = _payloadAndSignature(policy, payment);
+
+    vm.expectRevert(
+      abi.encodeWithSelector(
+        X402SessionSapientSigner.InvalidMaxPayments.selector, policy.maxPayments, signer.MAX_PERMIT2_NONCE_SLOTS()
+      )
+    );
+    vm.prank(address(wallet));
+    signer.recoverSapientSignature(payload, encoded);
+  }
+
+  function test_recoverSapientSignature_acceptsMaxPaymentsBoundarySlot() external {
+    X402SessionSapientSigner.Policy memory policy = _validPolicy();
+    policy.maxPayments = signer.MAX_PERMIT2_NONCE_SLOTS();
+    bytes32 policyRoot = signer.hashPolicy(policy);
+    uint256 nonceWord = signer.permit2NonceWord(address(wallet), policyRoot);
+    X402SessionSapientSigner.Permit2Payment memory payment = _validPayment(policy);
+    payment.nonce = (nonceWord << 8) | 255;
+    (Payload.Decoded memory payload, bytes memory encoded,) = _payloadAndSignature(policy, payment);
+
+    vm.prank(address(wallet));
+    assertEq(signer.recoverSapientSignature(payload, encoded), policyRoot);
+  }
+
+  function test_recoverSapientSignature_rejectsZeroPaymentAmount() external {
+    X402SessionSapientSigner.Policy memory policy = _validPolicy();
+    X402SessionSapientSigner.Permit2Payment memory payment = _validPayment(policy);
+    payment.amount = 0;
+    (Payload.Decoded memory payload, bytes memory encoded,) = _payloadAndSignature(policy, payment);
+
+    vm.expectRevert(
+      abi.encodeWithSelector(
+        X402SessionSapientSigner.InvalidPaymentAmount.selector, uint256(0), policy.maxAmountPerPayment
+      )
+    );
+    vm.prank(address(wallet));
+    signer.recoverSapientSignature(payload, encoded);
+  }
+
+  function test_recoverSapientSignature_rejectsApprovalWithMultipleCalls() external {
+    X402SessionSapientSigner.Policy memory policy = _validPolicy();
+    Payload.Decoded memory payload = _approvalPayload(TOKEN, PERMIT2, type(uint256).max);
+    Payload.Call memory approveCall = payload.calls[0];
+    payload.calls = new Payload.Call[](2);
+    payload.calls[0] = approveCall;
+    payload.calls[1] = approveCall;
+    bytes memory encoded = _approvalSignature(policy, payload);
+
+    vm.expectRevert(abi.encodeWithSelector(X402SessionSapientSigner.InvalidApprovalCallsLength.selector, uint256(2)));
+    vm.prank(address(wallet));
+    signer.recoverSapientSignature(payload, encoded);
+  }
+
+  function test_recoverSapientSignature_rejectsApprovalWithValue() external {
+    X402SessionSapientSigner.Policy memory policy = _validPolicy();
+    Payload.Decoded memory payload = _approvalPayload(TOKEN, PERMIT2, type(uint256).max);
+    payload.calls[0].value = 1;
+    bytes memory encoded = _approvalSignature(policy, payload);
+
+    vm.expectRevert(X402SessionSapientSigner.InvalidApprovalCall.selector);
+    vm.prank(address(wallet));
+    signer.recoverSapientSignature(payload, encoded);
+  }
+
+  function test_recoverSapientSignature_rejectsApprovalWithDelegateCall() external {
+    X402SessionSapientSigner.Policy memory policy = _validPolicy();
+    Payload.Decoded memory payload = _approvalPayload(TOKEN, PERMIT2, type(uint256).max);
+    payload.calls[0].delegateCall = true;
+    bytes memory encoded = _approvalSignature(policy, payload);
+
+    vm.expectRevert(X402SessionSapientSigner.InvalidApprovalCall.selector);
+    vm.prank(address(wallet));
+    signer.recoverSapientSignature(payload, encoded);
+  }
+
+  function test_recoverSapientSignature_rejectsApprovalOnlyFallback() external {
+    X402SessionSapientSigner.Policy memory policy = _validPolicy();
+    Payload.Decoded memory payload = _approvalPayload(TOKEN, PERMIT2, type(uint256).max);
+    payload.calls[0].onlyFallback = true;
+    bytes memory encoded = _approvalSignature(policy, payload);
+
+    vm.expectRevert(X402SessionSapientSigner.InvalidApprovalCall.selector);
+    vm.prank(address(wallet));
+    signer.recoverSapientSignature(payload, encoded);
+  }
+
+  function test_recoverSapientSignature_rejectsApprovalNonRevertBehavior() external {
+    X402SessionSapientSigner.Policy memory policy = _validPolicy();
+    Payload.Decoded memory payload = _approvalPayload(TOKEN, PERMIT2, type(uint256).max);
+    payload.calls[0].behaviorOnError = Payload.BEHAVIOR_IGNORE_ERROR;
+    bytes memory encoded = _approvalSignature(policy, payload);
+
+    vm.expectRevert(X402SessionSapientSigner.InvalidApprovalCall.selector);
+    vm.prank(address(wallet));
+    signer.recoverSapientSignature(payload, encoded);
+  }
+
+  function test_recoverSapientSignature_rejectsApprovalWrongDataLength() external {
+    X402SessionSapientSigner.Policy memory policy = _validPolicy();
+    Payload.Decoded memory payload = _approvalPayload(TOKEN, PERMIT2, type(uint256).max);
+    payload.calls[0].data = abi.encodePacked(APPROVE_SELECTOR);
+    bytes memory encoded = _approvalSignature(policy, payload);
+
+    vm.expectRevert(X402SessionSapientSigner.InvalidApprovalCall.selector);
+    vm.prank(address(wallet));
+    signer.recoverSapientSignature(payload, encoded);
+  }
+
+  function test_recoverSapientSignature_rejectsApprovalWrongSelector() external {
+    X402SessionSapientSigner.Policy memory policy = _validPolicy();
+    Payload.Decoded memory payload = _approvalPayload(TOKEN, PERMIT2, type(uint256).max);
+    bytes4 transferSelector = bytes4(keccak256("transfer(address,uint256)"));
+    payload.calls[0].data = abi.encodeWithSelector(transferSelector, PERMIT2, type(uint256).max);
+    bytes memory encoded = _approvalSignature(policy, payload);
+
+    vm.expectRevert(abi.encodeWithSelector(X402SessionSapientSigner.InvalidApprovalSelector.selector, transferSelector));
+    vm.prank(address(wallet));
+    signer.recoverSapientSignature(payload, encoded);
+  }
+
+  function test_recoverSapientSignature_rejectsAmountAbovePerPaymentLimit() external {
+    X402SessionSapientSigner.Policy memory policy = _validPolicy();
+    X402SessionSapientSigner.Permit2Payment memory payment = _validPayment(policy);
+    payment.amount = policy.maxAmountPerPayment + 1;
+    (Payload.Decoded memory payload, bytes memory encoded,) = _payloadAndSignature(policy, payment);
+
+    vm.expectRevert(
+      abi.encodeWithSelector(
+        X402SessionSapientSigner.InvalidPaymentAmount.selector, payment.amount, policy.maxAmountPerPayment
+      )
+    );
+    vm.prank(address(wallet));
+    signer.recoverSapientSignature(payload, encoded);
+  }
+
+  function test_recoverSapientSignature_rejectsNonceOutsideSessionWord() external {
+    X402SessionSapientSigner.Policy memory policy = _validPolicy();
+    bytes32 policyRoot = signer.hashPolicy(policy);
+    uint256 nonceWord = signer.permit2NonceWord(address(wallet), policyRoot);
+    X402SessionSapientSigner.Permit2Payment memory payment = _validPayment(policy);
+    payment.nonce = ((nonceWord + 1) << 8) | 1;
+    (Payload.Decoded memory payload, bytes memory encoded,) = _payloadAndSignature(policy, payment);
+
+    vm.expectRevert(
+      abi.encodeWithSelector(X402SessionSapientSigner.InvalidNonceWord.selector, nonceWord + 1, nonceWord)
+    );
+    vm.prank(address(wallet));
+    signer.recoverSapientSignature(payload, encoded);
+  }
+
+  function test_recoverSapientSignature_rejectsNonceSlotAbovePaymentLimit() external {
+    X402SessionSapientSigner.Policy memory policy = _validPolicy();
+    bytes32 policyRoot = signer.hashPolicy(policy);
+    uint256 nonceWord = signer.permit2NonceWord(address(wallet), policyRoot);
+    X402SessionSapientSigner.Permit2Payment memory payment = _validPayment(policy);
+    payment.nonce = (nonceWord << 8) | policy.maxPayments;
+    (Payload.Decoded memory payload, bytes memory encoded,) = _payloadAndSignature(policy, payment);
+
+    vm.expectRevert(
+      abi.encodeWithSelector(
+        X402SessionSapientSigner.InvalidNonceSlot.selector, uint256(policy.maxPayments), policy.maxPayments
+      )
+    );
+    vm.prank(address(wallet));
+    signer.recoverSapientSignature(payload, encoded);
+  }
+
+  function test_recoverSapientSignature_acceptsArbitraryRecipient() external {
+    X402SessionSapientSigner.Policy memory policy = _validPolicy();
+    X402SessionSapientSigner.Permit2Payment memory payment = _validPayment(policy);
+    payment.witnessTo = address(0xBEEF);
+    (Payload.Decoded memory payload, bytes memory encoded,) = _payloadAndSignature(policy, payment);
+
+    vm.prank(address(wallet));
+    bytes32 recovered = signer.recoverSapientSignature(payload, encoded);
+
+    assertEq(recovered, signer.hashPolicy(policy));
+  }
+
+  function test_isValidSignature_rejectsPolicyTokenOutsideConfiguredImage() external {
+    X402SessionSapientSigner.Policy memory configuredPolicy = _validPolicy();
+    wallet.setImageHash(_sequenceImageHash(address(signer), 1, signer.hashPolicy(configuredPolicy)));
+
+    X402SessionSapientSigner.Policy memory submittedPolicy = configuredPolicy;
+    submittedPolicy.token = address(0xBEEF);
+    X402SessionSapientSigner.Permit2Payment memory payment = _validPayment(submittedPolicy);
+    (Payload.Decoded memory payload, bytes memory encoded,) = _payloadAndSignature(submittedPolicy, payment);
+    bytes memory sequenceSignature = _encodeSequenceSapientSignature(address(signer), 1, encoded);
+
+    assertEq(wallet.isValidSignature(payload.digest, sequenceSignature), bytes4(0));
+  }
+
+  function test_recoverSapientSignature_rejectsMismatchedExternalDigest() external {
+    X402SessionSapientSigner.Policy memory policy = _validPolicy();
+    X402SessionSapientSigner.Permit2Payment memory payment = _validPayment(policy);
+    (, bytes memory encoded,) = _payloadAndSignature(policy, payment);
+
+    bytes32 wrongDigest = keccak256("wrong digest");
+    Payload.Decoded memory payload = Payload.fromDigest(wrongDigest);
+    bytes32 expectedDigest = signer.hashPermit2Payment(policy, payment);
+
+    vm.expectRevert(
+      abi.encodeWithSelector(X402SessionSapientSigner.InvalidDigest.selector, expectedDigest, wrongDigest)
+    );
+    vm.prank(address(wallet));
+    signer.recoverSapientSignature(payload, encoded);
+  }
+
+  function test_recoverSapientSignature_acceptsAnyChainPolicy() external {
+    X402SessionSapientSigner.Policy memory policy = _validPolicy();
+    policy.chainId = 0;
+    X402SessionSapientSigner.Permit2Payment memory payment = _validPayment(policy);
+    (Payload.Decoded memory payload, bytes memory encoded,) = _payloadAndSignature(policy, payment);
+
+    vm.prank(address(wallet));
+    bytes32 recovered = signer.recoverSapientSignature(payload, encoded);
+
+    assertEq(recovered, signer.hashPolicy(policy));
+  }
+
+  function test_recoverSapientSignature_rejectsWrongChainPolicy() external {
+    X402SessionSapientSigner.Policy memory policy = _validPolicy();
+    policy.chainId = block.chainid + 1;
+    X402SessionSapientSigner.Permit2Payment memory payment = _validPayment(policy);
+    (Payload.Decoded memory payload, bytes memory encoded,) = _payloadAndSignature(policy, payment);
+
+    vm.expectRevert(
+      abi.encodeWithSelector(X402SessionSapientSigner.InvalidChainId.selector, policy.chainId, block.chainid)
+    );
+    vm.prank(address(wallet));
+    signer.recoverSapientSignature(payload, encoded);
+  }
+
+  function test_recoverSapientSignature_rejectsInvalidSessionSignature() external {
+    X402SessionSapientSigner.Policy memory policy = _validPolicy();
+    X402SessionSapientSigner.Permit2Payment memory payment = _validPayment(policy);
+    bytes32 externalDigest = signer.hashPermit2Payment(policy, payment);
+    Payload.Decoded memory payload = Payload.fromDigest(externalDigest);
+    bytes32 policyRoot = signer.hashPolicy(policy);
+
+    Vm.Wallet memory wrongKey = vm.createWallet("wrong-key");
+    bytes32 authDigest = signer.hashSessionAuthorization(address(wallet), policyRoot, externalDigest);
+    bytes memory badSignature = _sign(wrongKey.privateKey, authDigest);
+    bytes memory encoded = _encode(policy, payment, badSignature);
+    address recovered = _recover(authDigest, badSignature);
+
+    vm.expectRevert(
+      abi.encodeWithSelector(X402SessionSapientSigner.InvalidSessionKeySignature.selector, recovered, policy.sessionKey)
+    );
+    vm.prank(address(wallet));
+    signer.recoverSapientSignature(payload, encoded);
+  }
+
+  function _validPayloadAndSignature()
+    internal
+    view
+    returns (Payload.Decoded memory payload, bytes memory encoded, bytes32 policyRoot)
+  {
+    X402SessionSapientSigner.Policy memory policy = _validPolicy();
+    X402SessionSapientSigner.Permit2Payment memory payment = _validPayment(policy);
+    return _payloadAndSignature(policy, payment);
+  }
+
+  function _approvalPayload(
+    address token,
+    address spender,
+    uint256 amount
+  ) internal pure returns (Payload.Decoded memory payload) {
+    payload.kind = Payload.KIND_TRANSACTIONS;
+    payload.calls = new Payload.Call[](1);
+    payload.calls[0] = Payload.Call({
+      to: token,
+      value: 0,
+      data: abi.encodeWithSelector(APPROVE_SELECTOR, spender, amount),
+      gasLimit: 0,
+      delegateCall: false,
+      onlyFallback: false,
+      behaviorOnError: Payload.BEHAVIOR_REVERT_ON_ERROR
+    });
+  }
+
+  function _packApproval(
+    address token,
+    address spender,
+    uint256 amount
+  ) internal pure returns (bytes memory) {
+    bytes memory data = abi.encodeWithSelector(APPROVE_SELECTOR, spender, amount);
+    return abi.encodePacked(
+      uint8(0x11), // global flag: space is zero (0x01) | single call (0x10)
+      uint8(0x44), // call flags: has data (0x04) | behavior revert-on-error (0x01 << 6)
+      token, // call target
+      uint24(data.length), // 3-byte calldata size
+      data
+    );
+  }
+
+  function _packApprovalInSpace(
+    address token,
+    address spender,
+    uint256 amount,
+    uint160 space
+  ) internal pure returns (bytes memory) {
+    bytes memory data = abi.encodeWithSelector(APPROVE_SELECTOR, spender, amount);
+    return abi.encodePacked(
+      uint8(0x10), // global flag: single call (0x10), space is non-zero (bit 0 clear)
+      space, // uint160 nonce space
+      uint8(0x44), // call flags: has data (0x04) | behavior revert-on-error (0x01 << 6)
+      token, // call target
+      uint24(data.length), // 3-byte calldata size
+      data
+    );
+  }
+
+  function _approvalPayloadAndSignature(
+    X402SessionSapientSigner.Policy memory policy,
+    address token,
+    address spender,
+    uint256 amount
+  ) internal view returns (Payload.Decoded memory payload, bytes memory encoded, bytes32 policyRoot) {
+    payload = _approvalPayload(token, spender, amount);
+    encoded = _approvalSignature(policy, payload);
+    policyRoot = signer.hashPolicy(policy);
+  }
+
+  function _approvalSignature(
+    X402SessionSapientSigner.Policy memory policy,
+    Payload.Decoded memory payload
+  ) internal view returns (bytes memory encoded) {
+    bytes32 policyRoot = signer.hashPolicy(policy);
+    bytes32 payloadDigest = Payload.hashFor(payload, address(wallet));
+    bytes32 authDigest = signer.hashSessionAuthorization(address(wallet), policyRoot, payloadDigest);
+    encoded = _encodeApproval(policy, _sign(sessionKey.privateKey, authDigest));
+  }
+
+  function _payloadAndSignature(
+    X402SessionSapientSigner.Policy memory policy,
+    X402SessionSapientSigner.Permit2Payment memory payment
+  ) internal view returns (Payload.Decoded memory payload, bytes memory encoded, bytes32 policyRoot) {
+    bytes32 externalDigest = signer.hashPermit2Payment(policy, payment);
+    payload = Payload.fromDigest(externalDigest);
+    policyRoot = signer.hashPolicy(policy);
+    bytes32 authDigest = signer.hashSessionAuthorization(address(wallet), policyRoot, externalDigest);
+    encoded = _encode(policy, payment, _sign(sessionKey.privateKey, authDigest));
+  }
+
+  function _validPolicy() internal view returns (X402SessionSapientSigner.Policy memory policy) {
+    policy.sessionKey = sessionKey.addr;
+    policy.chainId = block.chainid;
+    policy.token = TOKEN;
+    policy.maxAmountPerPayment = 1e6;
+    policy.maxPayments = 5;
+    policy.validBefore = 2000;
+  }
+
+  function _validPayment(
+    X402SessionSapientSigner.Policy memory policy
+  ) internal view returns (X402SessionSapientSigner.Permit2Payment memory payment) {
+    uint256 nonceWord = signer.permit2NonceWord(address(wallet), signer.hashPolicy(policy));
+    payment.amount = 1e6;
+    payment.nonce = (nonceWord << 8) | 2;
+    payment.deadline = 1800;
+    payment.witnessTo = PAY_TO;
+    payment.witnessValidAfter = 1000;
+  }
+
+  function _canonicalX402ProxyDigest(
+    X402SessionSapientSigner.Policy memory policy,
+    X402SessionSapientSigner.Permit2Payment memory payment
+  ) internal view returns (bytes32) {
+    bytes32 tokenPermissionsHash =
+      keccak256(abi.encode(CANONICAL_TOKEN_PERMISSIONS_TYPEHASH, policy.token, payment.amount));
+    bytes32 witnessHash =
+      keccak256(abi.encode(CANONICAL_WITNESS_TYPEHASH, payment.witnessTo, payment.witnessValidAfter));
+    bytes32 structHash = keccak256(
+      abi.encode(
+        CANONICAL_PERMIT2_WITNESS_TRANSFER_TYPEHASH,
+        tokenPermissionsHash,
+        X402_PERMIT2_PROXY,
+        payment.nonce,
+        payment.deadline,
+        witnessHash
+      )
+    );
+    bytes32 domainSeparator =
+      keccak256(abi.encode(CANONICAL_PERMIT2_DOMAIN_TYPEHASH, CANONICAL_PERMIT2_NAME_HASH, block.chainid, PERMIT2));
+    return keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
+  }
+
+  function _encode(
+    X402SessionSapientSigner.Policy memory policy,
+    X402SessionSapientSigner.Permit2Payment memory payment,
+    bytes memory sessionKeySignature
+  ) internal pure returns (bytes memory) {
+    X402SessionSapientSigner.X402Signature memory sig = X402SessionSapientSigner.X402Signature({
+      policy: policy, payment: payment, sessionKeySignature: sessionKeySignature
+    });
+    return abi.encode(sig);
+  }
+
+  function _encodeApproval(
+    X402SessionSapientSigner.Policy memory policy,
+    bytes memory sessionKeySignature
+  ) internal pure returns (bytes memory) {
+    X402SessionSapientSigner.ApprovalSignature memory sig =
+      X402SessionSapientSigner.ApprovalSignature({ policy: policy, sessionKeySignature: sessionKeySignature });
+    return abi.encode(sig);
+  }
+
+  function _sign(
+    uint256 privateKey,
+    bytes32 digest
+  ) internal pure returns (bytes memory) {
+    (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
+    return abi.encodePacked(r, s, v);
+  }
+
+  function _recover(
+    bytes32 digest,
+    bytes memory signature
+  ) internal pure returns (address recovered) {
+    bytes32 r;
+    bytes32 s;
+    uint8 v;
+    assembly {
+      r := mload(add(signature, 0x20))
+      s := mload(add(signature, 0x40))
+      v := byte(0, mload(add(signature, 0x60)))
+    }
+    recovered = ecrecover(digest, v, r, s);
+  }
+
+  function _sequenceImageHash(
+    address sapient,
+    uint256 weight,
+    bytes32 sapientImageHash
+  ) internal pure returns (bytes32 imageHash) {
+    bytes32 root = keccak256(abi.encodePacked("Sequence sapient config:\n", sapient, weight, sapientImageHash));
+    imageHash = _fkeccak256(root, bytes32(uint256(1)));
+    imageHash = _fkeccak256(imageHash, bytes32(0));
+    imageHash = _fkeccak256(imageHash, bytes32(0));
+  }
+
+  function _encodeSequenceSapientSignature(
+    address sapient,
+    uint8 weight,
+    bytes memory sapientSignature
+  ) internal pure returns (bytes memory) {
+    require(weight > 0 && weight < 4, "unsupported weight");
+    bytes1 sapientItemFlag = bytes1(uint8(0x90 | 0x08 | weight));
+    return abi.encodePacked(
+      bytes1(0x00), bytes1(0x01), sapientItemFlag, sapient, uint16(sapientSignature.length), sapientSignature
+    );
+  }
+
+  function _fkeccak256(
+    bytes32 a,
+    bytes32 b
+  ) internal pure returns (bytes32 c) {
+    assembly {
+      mstore(0, a)
+      mstore(32, b)
+      c := keccak256(0, 64)
+    }
+  }
+
+}


### PR DESCRIPTION
Draft implementation of `X402SessionSapientSigner` — a digest-aware sapient signer that lets a Sequence wallet authorize x402 `exact` Permit2 payments under a committed, session-scoped policy.

- **Payments**: reconstructs the canonical x402 Permit2 witness-transfer digest, validates it against the policy (token, per-payment cap, payment count via a deterministic Permit2 nonce word/slot, expiry, chain), and requires a wallet-bound session-key signature.
- **Setup**: also authorizes a single `token.approve(PERMIT2, max)` transaction (`KIND_TRANSACTIONS`) so a session can self-provision its Permit2 allowance.

Design rationale and trust assumptions in `docs/X402_SMART_SESSIONS.md`. 39 tests, including end-to-end `execute`/`isValidSignature` paths.